### PR TITLE
rename SwitchEntity to SwitchDevice

### DIFF
--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -22,12 +22,12 @@ switch:
       sw02:
         name: usb_plug
         friendly_name: USB Plug
-        id: 7  
+        id: 7
 """
 import logging
 import voluptuous as vol
 
-from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity, PLATFORM_SCHEMA
+from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchDevice, PLATFORM_SCHEMA
 from homeassistant.const import (CONF_HOST, CONF_ID, CONF_SWITCHES, CONF_FRIENDLY_NAME, CONF_ICON, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 from time import time, sleep
@@ -194,7 +194,7 @@ class TuyaCache:
         finally:
             self._lock.release()
 
-class TuyaDevice(SwitchEntity):
+class TuyaDevice(SwitchDevice):
     """Representation of a Tuya switch."""
 
     def __init__(self, device, name, friendly_name, icon, switchid, attr_current, attr_consumption, attr_voltage):


### PR DESCRIPTION
Some time ago few main components in the Home Assistant were renamed, one of them was the SwitchEntity. This causes an import error since SwitchEntity cannot be find anymore. I was manually changing this in your library after every patch, but I guess it would be nice to have a permanent fix there ;)