### PR TITLE
Add support for unique_id and available

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -29,7 +29,7 @@ from homeassistant.components.cover import (
 )
 
 """from . import DATA_TUYA, TuyaDevice"""
-from homeassistant.components.cover import ENTITY_ID_FORMAT, CoverEntity, PLATFORM_SCHEMA
+from homeassistant.components.cover import CoverEntity, PLATFORM_SCHEMA
 from homeassistant.const import (CONF_HOST, CONF_ID, CONF_FRIENDLY_NAME, CONF_ICON, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 from time import time, sleep
@@ -88,7 +88,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     print('Setup localtuya cover [{}] with device ID [{}] '.format(config.get(CONF_FRIENDLY_NAME), config.get(CONF_ID)))
     _LOGGER.info("Setup localtuya cover %s with device ID %s ", config.get(CONF_FRIENDLY_NAME), config.get(CONF_ID) )
 
-    add_entities(covers)
+    add_entities(covers, True)
 
 
 class TuyaCoverCache:
@@ -100,6 +100,11 @@ class TuyaCoverCache:
         self._cached_status_time = 0
         self._device = device
         self._lock = Lock()
+
+    @property
+    def unique_id(self):
+        """Return unique device identifier."""
+        return self._device.id
 
     def __get_status(self):
         for i in range(5):
@@ -146,7 +151,7 @@ class TuyaDevice(CoverEntity):
 
     def __init__(self, device, name, friendly_name, icon, switchid):
         self._device = device
-        self.entity_id =  ENTITY_ID_FORMAT.format(name)
+        self._available = False
         self._name = friendly_name
         self._friendly_name = friendly_name
         self._icon = icon
@@ -160,6 +165,16 @@ class TuyaDevice(CoverEntity):
     def name(self):
         """Get name of Tuya switch."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return unique device identifier."""
+        return self._device.unique_id
+
+    @property
+    def available(self):
+        """Return if device is available or not."""
+        return self._available
 
     @property
     def supported_features(self):
@@ -252,6 +267,11 @@ class TuyaDevice(CoverEntity):
 
     def update(self):
         """Get state of Tuya switch."""
-        self._status = self._device.status()
-        self._state = self._status['dps'][self._switch_id]
-        #print('update() : state [{}]'.format(self._state))
+        try:
+            self._status = self._device.status()
+            self._state = self._status['dps'][self._switch_id]
+            #print('update() : state [{}]'.format(self._state))
+        except Exception:
+            self._available = False
+        else:
+            self._available = True

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -169,7 +169,7 @@ class TuyaDevice(CoverEntity):
     @property
     def unique_id(self):
         """Return unique device identifier."""
-        return self._device.unique_id
+        return f"local_{self._device.unique_id}"
 
     @property
     def available(self):

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -214,7 +214,7 @@ class TuyaDevice(Light):
     @property
     def unique_id(self):
         """Return unique device identifier."""
-        return self._device.unique_id
+        return f"local_{self._device.unique_id}"
 
     @property
     def available(self):

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -86,6 +86,11 @@ class TuyaCache:
         self._device = device
         self._lock = Lock()
 
+    @property
+    def unique_id(self):
+        """Return unique device identifier."""
+        return self._device.id
+
     def __get_status(self, switchid):
         for _ in range(UPDATE_RETRY_LIMIT):
             try:
@@ -193,6 +198,7 @@ class TuyaDevice(Light):
     def __init__(self, device, name, icon, bulbid):
         """Initialize the Tuya switch."""
         self._device = device
+        self._available = False
         self._name = name
         self._state = False
         self._brightness = 127
@@ -206,6 +212,16 @@ class TuyaDevice(Light):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return unique device identifier."""
+        return self._device.unique_id
+
+    @property
+    def available(self):
+        """Return if device is available or not."""
+        return self._available
+
+    @property
     def is_on(self):
         """Check if Tuya switch is on."""
         return self._state
@@ -217,6 +233,14 @@ class TuyaDevice(Light):
 
     def update(self):
         """Get state of Tuya switch."""
+        try:
+            self._update_state()
+        except:
+            self._available = False
+        else:
+            self._available = True
+
+    def _update_state(self):
         status = self._device.status(self._bulb_id)
         self._state = status
         try:

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -224,7 +224,7 @@ class TuyaDevice(SwitchEntity):
     @property
     def unique_id(self):
         """Return unique device identifier."""
-        return self._device.unique_id
+        return f"local_{self._device.unique_id}"
 
     @property
     def available(self):


### PR DESCRIPTION
This adds support for `unique_id` and `available`. Benefits are:

* A config entry will be created so that entity name and friendly name can be changed from UI
* The device will appear as `unavailable` if an update fails, e.g. due to network problems, which makes it easier to spot if a device is not working