### PR TITLE
Add support for config flow option

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -6,6 +6,8 @@ ATTR_VOLTAGE = 'voltage'
 
 CONF_LOCAL_KEY = "local_key"
 CONF_PROTOCOL_VERSION = "protocol_version"
+CONF_DPS_STRINGS = "dps_strings"
+CONF_YAML_IMPORT = "yaml_import"
 
 # switch
 CONF_CURRENT = "current"

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -31,7 +31,7 @@
             },
             "add_entity": {
                 "title": "Add new entity",
-                "description": "Please fill out the details for an entity with type `{platform}`.",
+                "description": "Please fill out the details for an entity with type `{platform}`. All settings except for `ID` can be changed from the Options page later.",
                 "data": {
                     "id": "ID",
                     "friendly_name": "Friendly name",
@@ -42,6 +42,38 @@
                     "close_cmd": "Close Command",
                     "stop_cmd": "Stop Command"
                 }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Configure Tuya Device",
+                "description": "Basic configuration for device id `{device_id}`.",
+                "data": {
+                    "friendly_name": "Friendly Name",
+                    "host": "Host",
+                    "local_key": "Local key",
+                    "protocol_version": "Protocol Version"
+                }
+            },
+            "entity": {
+                "title": "Entity Configuration",
+                "description": "Editing entity with DPS `{id}` and platform `{platform}`.",
+                "data": {
+                    "id": "ID",
+                    "friendly_name": "Friendly name",
+                    "current": "Current",
+                    "current_consumption": "Current Consumption",
+                    "voltage": "Voltage",
+                    "open_cmd": "Open Command",
+                    "close_cmd": "Close Command",
+                    "stop_cmd": "Stop Command"
+                }
+            },
+            "yaml_import": {
+                "title": "Not Supported",
+                "description": "Options cannot be edited when configured via YAML."
             }
         }
     },


### PR DESCRIPTION
This brings generic support for options to all platforms. It basically triggers the same steps as when adding a new device (with the configured entities). A few things to note:

* Not supported for YAML configs. This is basically because the YAML config overwrites what's stored in the config entry every time Home Assistant is restarted, so this kinda loses the point.
* It is not possible to change device id or id for any of the platforms. The ids are used to derive unique identifiers and allowing to change them will seriously mess things up. You basically create new devices and entities when doing so.
* Changes are not reflected until Home Assistant is restarted for now. I will change this, but it requires some refactoring.
* DPS values supported by a device is cached in the config entry, so the same choices are available in the options dialog. If DPS values are not present in the config entry, a list with choice from 1-255 is generated. This should be backwards compatible.

This change needs some serious testing, so please make sure to test this before merging!