### PR TITLE
Major refactor of cover platform and config flow support tweaks for cover platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 __pycache__
+custom_components/.DS_Store
+.DS_Store

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_FRIENDLY_NAME,
     CONF_PLATFORM,
     CONF_SWITCHES,
+    CONF_COVERS,
 )
 
 from . import pytuya
@@ -149,10 +150,7 @@ class LocaltuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle adding a new entity."""
         errors = {}
         if user_input is not None:
-            already_configured = any(
-                switch[CONF_ID] == user_input[CONF_ID] for switch in self.entities
-            )
-            if not already_configured:
+            already_configured = any(switch[CONF_ID] == user_input[CONF_ID] for switch in self.entities) or any(cover[CONF_ID] == user_input[CONF_ID] for cover in self.entities)              if not already_configured:
                 user_input[CONF_PLATFORM] = self.platform
                 self.entities.append(strip_dps_values(user_input, self.dps_strings))
                 return await self.async_step_pick_entity_type()
@@ -183,8 +181,11 @@ class LocaltuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._set_platform(user_input[CONF_PLATFORM])
 
         if len(user_input.get(CONF_SWITCHES, [])) > 0:
-            for switch_conf in user_input[CONF_SWITCHES].values():
-                self.entities.append(_convert_entity(switch_conf))
+                    for switch_conf in user_input[CONF_SWITCHES].values():
+                        self.entities.append(_convert_entity(switch_conf))
+        elif len(user_input.get(CONF_COVERS, [])) > 0:
+            for cover_conf in user_input[CONF_COVERS].values():
+                self.entities.append(_convert_entity(cover_conf))
         else:
             self.entities.append(_convert_entity(user_input))
 

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -13,9 +13,18 @@ CONF_CURRENT_CONSUMPTION = "current_consumption"
 CONF_VOLTAGE = "voltage"
 
 # cover
-CONF_OPEN_CMD = 'open_cmd'
-CONF_CLOSE_CMD = 'close_cmd'
-CONF_STOP_CMD = 'stop_cmd'
+ATTR_OPEN_CMD = "open_cmd"
+ATTR_CLOSE_CMD = "close_cmd"
+ATTR_STOP_CMD = "stop_cmd"
+ATTR_GET_POSITION_KEY = "get_position_key"
+ATTR_SET_POSITION_KEY = "set_position_key"
+CONF_OPEN_CMD = "open_cmd"
+CONF_CLOSE_CMD = "close_cmd"
+CONF_STOP_CMD = "stop_cmd"
+CONF_GET_POSITION_KEY = "get_position_key"
+CONF_SET_POSITION_KEY = "set_position_key"
+CONF_COVER_COMMAND_KEY = "cover_command_key"
+CONF_LAST_MOVEMENT_KEY = "last_movement_key"
 
 DOMAIN = "localtuya"
 

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -40,7 +40,11 @@
                     "voltage": "Voltage",
                     "open_cmd": "Open Command",
                     "close_cmd": "Close Command",
-                    "stop_cmd": "Stop Command"
+                    "stop_cmd": "Stop Command",
+                    "get_position_key": "Get Position Key",
+                    "set_position_key": "Set Position Key",
+                    "cover_command_key": "Open/Close/Stop Key",
+                    "last_movement_key": "Last Movement Key"
                 }
             }
         }


### PR DESCRIPTION
I'm bad at GitHub and didn't know how to update my old PR to run on top of the new master. Therefore, i'm closing https://github.com/rospogrigio/localtuya-homeassistant/pull/10 and opening this new PR. I'm now getting the following error when setting up a cover from the config flow:

```
2020-09-16 01:17:29 ERROR (MainThread) [homeassistant.components.cover] Error while setting up localtuya platform for cover
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 184, in _async_setup_platform
    await asyncio.shield(task)
  File "/config/custom_components/localtuya/cover.py", line 111, in async_setup_entry
    TuyaCache(device, config_entry.data[CONF_FRIENDLY_NAME]),
KeyError: 'friendly_name'`
```

@postlund @rospogrigio can either of you help me debug? My efforts to fix the error have thus far been unfruitful.