### PR TITLE
Handling of dps to request in the payload

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -55,6 +55,11 @@ def prepare_setup_entities(config_entry, platform):
         config_entry.data[CONF_LOCAL_KEY],
     )
     device.set_version(float(config_entry.data[CONF_PROTOCOL_VERSION]))
+
+    for device_config in entities_to_setup:
+        # this has to be done in case the device type is type_0d
+        device.add_dps_to_request(device_config[CONF_ID])
+
     return device, entities_to_setup
 
 

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -55,7 +55,6 @@ def prepare_setup_entities(config_entry, platform):
         config_entry.data[CONF_LOCAL_KEY],
     )
     device.set_version(float(config_entry.data[CONF_PROTOCOL_VERSION]))
-    device.set_dpsUsed({})
     return device, entities_to_setup
 
 

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -51,7 +51,6 @@ from .const import (
     CONF_STOP_CMD,
 )
 from .const import CONF_OPEN_CMD, CONF_CLOSE_CMD, CONF_STOP_CMD
-from .pytuya import TuyaDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,9 +87,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     covers = []
     for device_config in entities_to_setup:
-        # this has to be done in case the device type is type_0d
-        device.add_dps_to_request(device_config[CONF_ID])
-
         covers.append(
             LocaltuyaCover(
                 TuyaCache(device, config_entry.data[CONF_FRIENDLY_NAME]),

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -86,12 +86,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     if not entities_to_setup:
         return
 
-    # TODO: keeping for now but should be removed
-    dps = {}
-
     covers = []
     for device_config in entities_to_setup:
-        dps[device_config[CONF_ID]] = None
+        # this has to be done in case the device type is type_0d
+        device.add_dps_to_request(device_config[CONF_ID])
+
         covers.append(
             LocaltuyaCover(
                 TuyaCache(device, config_entry.data[CONF_FRIENDLY_NAME]),
@@ -100,7 +99,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             )
         )
 
-    device.set_dpsUsed(dps)
     async_add_entities(covers, True)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -61,6 +61,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     lights = []
     for device_config in entities_to_setup:
+        # this has to be done in case the device type is type_0d
+        device.add_dps_to_request(device_config[CONF_ID])
+
         lights.append(
             LocaltuyaLight(
                 TuyaCache(device, config_entry.data[CONF_FRIENDLY_NAME]),

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -250,8 +250,7 @@ class TuyaDevice(object):
 
         # dps 1 must always be sent, otherwise it might fail in case no dps is found in the requested range
         self.dps_to_request = {"1": None}
-        for dps in range(2, 11):
-            self.add_dps_to_request(dps)
+        self.add_dps_to_request(range(2, 11))
         try:
             data = self.status()
         except Exception as e:
@@ -263,8 +262,7 @@ class TuyaDevice(object):
             return detected_dps
 
         self.dps_to_request = {"1": None}
-        for dps in range(11, 21):
-            self.add_dps_to_request(dps)
+        self.add_dps_to_request(range(11, 21))
         try:
             data = self.status()
         except Exception as e:
@@ -273,8 +271,7 @@ class TuyaDevice(object):
         detected_dps.update( data["dps"] )
 
         self.dps_to_request = {"1": None}
-        for dps in range(21, 31):
-            self.add_dps_to_request(dps)
+        self.add_dps_to_request(range(21, 31))
         try:
             data = self.status()
         except Exception as e:
@@ -283,8 +280,7 @@ class TuyaDevice(object):
         detected_dps.update( data["dps"] )
 
         self.dps_to_request = {"1": None}
-        for dps in range(100, 111):
-            self.add_dps_to_request(dps)
+        self.add_dps_to_request(range(100, 111))
         try:
             data = self.status()
         except Exception as e:
@@ -296,7 +292,10 @@ class TuyaDevice(object):
         return detected_dps
 
     def add_dps_to_request(self, dps_index):
-        self.dps_to_request[str(dps_index)] = None
+        if isinstance(dps_index, int):
+            self.dps_to_request[str(dps_index)] = None
+        else:
+            self.dps_to_request.update({str(index): None for index in dps_index})
 
     def generate_payload(self, command, data=None):
         """

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -101,14 +101,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     switches = []
     for device_config in entities_to_setup:
-        # this has to be done in case the device type is type_0d
-        device.add_dps_to_request(device_config[CONF_ID])
-        if device_config[CONF_CURRENT] != "-1":
-            device.add_dps_to_request(device_config[CONF_CURRENT])
-        if device_config[CONF_CURRENT_CONSUMPTION] != "-1":
-            device.add_dps_to_request(device_config[CONF_CURRENT_CONSUMPTION])
-        if device_config[CONF_VOLTAGE] != "-1":
-            device.add_dps_to_request(device_config[CONF_VOLTAGE])
+        if device_config.get(CONF_CURRENT, "-1") != "-1":
+            device.add_dps_to_request(device_config.get(CONF_CURRENT))
+        if device_config.get(CONF_CURRENT_CONSUMPTION, "-1") != "-1":
+            device.add_dps_to_request(device_config.get(CONF_CURRENT_CONSUMPTION))
+        if device_config.get(CONF_VOLTAGE, "-1") != "-1":
+            device.add_dps_to_request(device_config.get(CONF_VOLTAGE))
 
         switches.append(
             LocaltuyaSwitch(
@@ -127,8 +125,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class TuyaCache:
-    """Cache wrapper for pytuya.TuyaDevice"""
-
     def __init__(self, device, friendly_name):
         """Initialize the cache."""
         self._cached_status = ""
@@ -222,13 +218,13 @@ class LocaltuyaSwitch(LocalTuyaEntity, SwitchEntity):
     @property
     def device_state_attributes(self):
         attrs = {}
-        if CONF_CURRENT in self._config:
+        if self._config.get(CONF_CURRENT, "-1") != "-1":
             attrs[ATTR_CURRENT] = self.dps(self._config[CONF_CURRENT])
-        if CONF_CURRENT_CONSUMPTION in self._config:
+        if self._config.get(ATTR_CURRENT_CONSUMPTION, "-1") != "-1":
             attrs[ATTR_CURRENT_CONSUMPTION] = (
                 self.dps(self._config[CONF_CURRENT_CONSUMPTION]) / 10
             )
-        if CONF_VOLTAGE in self._config:
+        if self._config.get(CONF_VOLTAGE, "-1") != "-1":
             attrs[ATTR_VOLTAGE] = self.dps(self._config[CONF_VOLTAGE]) / 10
         return attrs
 

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -101,6 +101,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     switches = []
     for device_config in entities_to_setup:
+        # this has to be done in case the device type is type_0d
+        device.add_dps_to_request(device_config[CONF_ID])
+        if device_config[CONF_CURRENT] != "-1":
+            device.add_dps_to_request(device_config[CONF_CURRENT])
+        if device_config[CONF_CURRENT_CONSUMPTION] != "-1":
+            device.add_dps_to_request(device_config[CONF_CURRENT_CONSUMPTION])
+        if device_config[CONF_VOLTAGE] != "-1":
+            device.add_dps_to_request(device_config[CONF_VOLTAGE])
+
         switches.append(
             LocaltuyaSwitch(
                 TuyaCache(device, config_entry.data[CONF_FRIENDLY_NAME]),


### PR DESCRIPTION
In pytuya, renamed set_dpsUsed into add_dps_to_request , which accepts single dps indexes instead of a list.
Used it when setting up entities.