### PR TITLE
Fix missing attributes bug

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -184,6 +184,11 @@ class LocalTuyaEntity(Entity):
         """Return unique device identifier."""
         return f"local_{self._device.unique_id}_{self._dps_id}"
 
+    def has_config(self, attr):
+        """Return if a config parameter has a valid value."""
+        value = self._config.get(attr, "-1")
+        return value is not None and value != "-1"
+
     @property
     def available(self):
         """Return if device is available or not."""

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -80,13 +80,13 @@ class LocaltuyaSwitch(LocalTuyaEntity, SwitchEntity):
     def device_state_attributes(self):
         """Return device state attributes."""
         attrs = {}
-        if self._config.get(CONF_CURRENT, "-1") != "-1":
+        if self.has_config(CONF_CURRENT):
             attrs[ATTR_CURRENT] = self.dps(self._config[CONF_CURRENT])
-        if self._config.get(ATTR_CURRENT_CONSUMPTION, "-1") != "-1":
+        if self.has_config(CONF_CURRENT_CONSUMPTION):
             attrs[ATTR_CURRENT_CONSUMPTION] = (
                 self.dps(self._config[CONF_CURRENT_CONSUMPTION]) / 10
             )
-        if self._config.get(CONF_VOLTAGE, "-1") != "-1":
+        if self.has_config(CONF_VOLTAGE):
             attrs[ATTR_VOLTAGE] = self.dps(self._config[CONF_VOLTAGE]) / 10
         return attrs
 


### PR DESCRIPTION
This should fix the bug reported on the community forums:

```python
...
File “/config/custom_components/localtuya/switch.py”, line 220, in device_state_attributes
self.dps(self._config[CONF_CURRENT_CONSUMPTION]) / 10
TypeError: unsupported operand type(s) for /: ‘NoneType’ and ‘int’
...
```