### PR TITLE
Fix fan fails on Home assistant restart.

### DIFF
--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -84,11 +84,10 @@ class TuyaDevice(FanEntity):
         """Initialize the entity."""
         self._device = device
         self._name = friendly_name
-        self._available = False
+        self._available = True
         self._friendly_name = friendly_name
         self._icon = icon
         self._switch_id = switchid
-        self._status = self._device.status()
         self._state = False
         self._supported_features = SUPPORT_SET_SPEED | SUPPORT_OSCILLATE
         self._speed = STATE_OFF


### PR DESCRIPTION
Some time when Home assistant was restarted it would fail to setup device.