### PR TITLE
Add color temp and brightness config to light

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -33,6 +33,8 @@ localtuya:
       - platform: light
         friendly_name: Device Light
         id: 4
+        brightness: 20
+        color_temp: 21
 
       - platform: sensor
         friendly_name: Plug Voltage

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -261,7 +261,7 @@ class LocalTuyaEntity(Entity):
         return value
 
     def dps_conf(self, conf_item):
-        """Return value of datapoint for user speified config item.
+        """Return value of datapoint for user specified config item.
 
         This method looks up which DP a certain config item uses based on
         user configuration and returns its value.

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -260,6 +260,14 @@ class LocalTuyaEntity(Entity):
 
         return value
 
+    def dps_conf(self, conf_item):
+        """Return value of datapoint for user speified config item.
+
+        This method looks up which DP a certain config item uses based on
+        user configuration and returns its value.
+        """
+        return self.dps(self._config.get(conf_item))
+
     def status_updated(self):
         """Device status was updated.
 

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -16,6 +16,7 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
     SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR_TEMP,
     SUPPORT_COLOR,
 )
 
@@ -85,7 +86,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         """Flag supported features."""
         supports = SUPPORT_BRIGHTNESS
         if self._color_temp is not None:
-            supports = supports | SUPPORT_COLOR
+            supports = supports | SUPPORT_COLOR_TEMP
         return supports
 
     def turn_on(self, **kwargs):

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -5,7 +5,6 @@ from functools import partial
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_ID,
     CONF_BRIGHTNESS,
     CONF_COLOR_TEMP,
 )
@@ -17,7 +16,6 @@ from homeassistant.components.light import (
     ATTR_HS_COLOR,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR_TEMP,
-    SUPPORT_COLOR,
 )
 
 from .common import LocalTuyaEntity, async_setup_entry
@@ -26,7 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 
 MIN_MIRED = 153
 MAX_MIRED = 370
-UPDATE_RETRY_LIMIT = 3
 
 
 def flow_schema(dps):

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -55,7 +55,9 @@
                     "device_class": "Device Class",
                     "scaling": "Scaling Factor",
                     "state_on": "On Value",
-                    "state_off": "Off Value"
+                    "state_off": "Off Value",
+                    "brightness": "Brightness",
+                    "color_temp": "Color Temperature"
                 }
             }
         }
@@ -90,7 +92,9 @@
                     "device_class": "Device Class",
                     "scaling": "Scaling Factor",
                     "state_on": "On Value",
-                    "state_off": "Off Value"
+                    "state_off": "Off Value",
+                    "brightness": "Brightness",
+                    "color_temp": "Color Temperature"
                 }
             },
             "yaml_import": {


### PR DESCRIPTION
This makes it possible to specify DP for brightness and color temperature via YAML config and config flow. Should be tested before merging.