### PR TITLE
Move to component from platform schemas

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -1,4 +1,51 @@
-"""The LocalTuya integration integration."""
+"""The LocalTuya integration integration.
+
+Sample YAML config with all supported entity types (default values
+are pre-filled for optional fields):
+
+localtuya:
+  - host: 192.168.1.x
+    device_id: xxxxx
+    local_key: xxxxx
+    friendly_name: Tuya Device
+    protocol_version: "3.3"
+    entities:
+      - platform: binary_sensor
+        friendly_name: Plug Status
+        id: 1
+        device_class: power
+        state_on: "true" # Optional
+        state_off: "false" # Optional
+
+      - platform: cover
+        friendly_name: Device Cover
+        id: 2
+        open_cmd: "on" # Optional
+        close_cmd: "off" # Optional
+        stop_cmd: "stop" # Optional
+
+      - platform: fan
+        friendly_name: Device Fan
+        id: 3
+
+      - platform: light
+        friendly_name: Device Light
+        id: 4
+
+      - platform: sensor
+        friendly_name: Plug Voltage
+        id: 20
+        scaling: 0.1 # Optional
+        device_class: voltage # Optional
+        unit_of_measurement: "V" # Optional
+
+      - platform: switch
+        friendly_name: Plug
+        id: 1
+        current: 18 # Optional
+        current_consumption: 19 # Optional
+        voltage: 20 # Optional
+"""
 import asyncio
 import logging
 

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -1,48 +1,22 @@
 """The LocalTuya integration integration."""
 import asyncio
 import logging
-import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.const import (
-    CONF_DEVICE_ID,
-    CONF_ID,
-    CONF_ICON,
-    CONF_NAME,
-    CONF_FRIENDLY_NAME,
-    CONF_HOST,
     CONF_PLATFORM,
     CONF_ENTITIES,
 )
-import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_LOCAL_KEY, CONF_PROTOCOL_VERSION, DOMAIN
-
-
-import pprint
-
-pp = pprint.PrettyPrinter(indent=4)
+from .const import DOMAIN
+from .config_flow import config_schema
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_ID = "1"
-DEFAULT_PROTOCOL_VERSION = 3.3
-
 UNSUB_LISTENER = "unsub_listener"
 
-BASE_PLATFORM_SCHEMA = {
-    vol.Optional(CONF_ICON): cv.icon,  # Deprecated: not used
-    vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_DEVICE_ID): cv.string,
-    vol.Required(CONF_LOCAL_KEY): cv.string,
-    vol.Optional(CONF_NAME): cv.string,  # Deprecated: not used
-    vol.Required(CONF_FRIENDLY_NAME): cv.string,
-    vol.Required(CONF_PROTOCOL_VERSION, default=DEFAULT_PROTOCOL_VERSION): vol.Coerce(
-        float
-    ),
-    vol.Optional(CONF_ID, default=DEFAULT_ID): cv.string,
-}
+CONFIG_SCHEMA = config_schema()
 
 
 def import_from_yaml(hass, config, platform):
@@ -60,6 +34,8 @@ def import_from_yaml(hass, config, platform):
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the LocalTuya integration component."""
     hass.data.setdefault(DOMAIN, {})
+
+    print("setup:", config.get(DOMAIN))
     return True
 
 

--- a/custom_components/localtuya/binary_sensor.py
+++ b/custom_components/localtuya/binary_sensor.py
@@ -23,7 +23,6 @@ import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
     DOMAIN,
-    PLATFORM_SCHEMA,
     DEVICE_CLASSES_SCHEMA,
     BinarySensorEntity,
 )
@@ -33,19 +32,12 @@ from homeassistant.const import (
     CONF_FRIENDLY_NAME,
 )
 
-from . import (
-    BASE_PLATFORM_SCHEMA,
-    LocalTuyaEntity,
-    prepare_setup_entities,
-    import_from_yaml,
-)
+from .common import LocalTuyaEntity, prepare_setup_entities
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_STATE_ON = "state_on"
 CONF_STATE_OFF = "state_off"
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(BASE_PLATFORM_SCHEMA)
 
 
 def flow_schema(dps):
@@ -74,11 +66,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
 
     async_add_entities(sensors, True)
-
-
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up of the Tuya sensor."""
-    return import_from_yaml(hass, config, DOMAIN)
 
 
 class TuyaCache:

--- a/custom_components/localtuya/binary_sensor.py
+++ b/custom_components/localtuya/binary_sensor.py
@@ -1,20 +1,4 @@
-"""
-Platform to prsent any Tuya DP as a binary sensor.
-
-Sample config yaml
-
-sensor:
-  - platform: localtuya
-    host: 192.168.0.1
-    local_key: 1234567891234567
-    device_id: 12345678912345671234
-    friendly_name: Current
-    protocol_version: 3.3
-    id: 18
-    state_on: "true" (optional, default is "true")
-    state_off: "false" (optional, default is "false")
-    device_class: current
-"""
+"""Platform to present any Tuya DP as a binary sensor."""
 import logging
 
 import voluptuous as vol

--- a/custom_components/localtuya/binary_sensor.py
+++ b/custom_components/localtuya/binary_sensor.py
@@ -16,8 +16,6 @@ sensor:
     device_class: current
 """
 import logging
-from time import time, sleep
-from threading import Lock
 
 import voluptuous as vol
 
@@ -26,11 +24,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA,
     BinarySensorEntity,
 )
-from homeassistant.const import (
-    CONF_ID,
-    CONF_DEVICE_CLASS,
-    CONF_FRIENDLY_NAME,
-)
+from homeassistant.const import CONF_ID, CONF_DEVICE_CLASS
 
 from .common import LocalTuyaEntity, prepare_setup_entities
 
@@ -51,7 +45,9 @@ def flow_schema(dps):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a Tuya sensor based on a config entry."""
-    device, entities_to_setup = prepare_setup_entities(config_entry, DOMAIN)
+    tuyainterface, entities_to_setup = prepare_setup_entities(
+        hass, config_entry, DOMAIN
+    )
     if not entities_to_setup:
         return
 
@@ -59,81 +55,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for device_config in entities_to_setup:
         sensors.append(
             LocaltuyaBinarySensor(
-                TuyaCache(device, config_entry.data[CONF_FRIENDLY_NAME]),
+                tuyainterface,
                 config_entry,
                 device_config[CONF_ID],
             )
         )
 
     async_add_entities(sensors, True)
-
-
-class TuyaCache:
-    """Cache wrapper for pytuya.TuyaDevice."""
-
-    def __init__(self, device, friendly_name):
-        """Initialize the cache."""
-        self._cached_status = ""
-        self._cached_status_time = 0
-        self._device = device
-        self._friendly_name = friendly_name
-        self._lock = Lock()
-
-    @property
-    def unique_id(self):
-        """Return unique device identifier."""
-        return self._device.id
-
-    def __get_status(self):
-        for i in range(5):
-            try:
-                status = self._device.status()
-                return status
-            except Exception:
-                print(
-                    "Failed to update status of device [{}]".format(
-                        self._device.address
-                    )
-                )
-                sleep(1.0)
-                if i + 1 == 3:
-                    _LOGGER.error(
-                        "Failed to update status of device %s", self._device.address
-                    )
-                    #                    return None
-                    raise ConnectionError("Failed to update status .")
-
-    def set_dps(self, state, dps_index):
-        """Change the Tuya sensor status and clear the cache."""
-        self._cached_status = ""
-        self._cached_status_time = 0
-        for i in range(5):
-            try:
-                return self._device.set_dps(state, dps_index)
-            except Exception:
-                print(
-                    "Failed to set status of device [{}]".format(self._device.address)
-                )
-                if i + 1 == 3:
-                    _LOGGER.error(
-                        "Failed to set status of device %s", self._device.address
-                    )
-                    return
-
-        #                    raise ConnectionError("Failed to set status.")
-
-    def status(self):
-        """Get state of Tuya sensor and cache the results."""
-        self._lock.acquire()
-        try:
-            now = time()
-            if not self._cached_status or now - self._cached_status_time > 15:
-                sleep(0.5)
-                self._cached_status = self.__get_status()
-                self._cached_status_time = time()
-            return self._cached_status
-        finally:
-            self._lock.release()
 
 
 class LocaltuyaBinarySensor(LocalTuyaEntity, BinarySensorEntity):

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -54,7 +54,7 @@ class TuyaDevice:
             config_entry[CONF_DEVICE_ID],
             config_entry[CONF_HOST],
             config_entry[CONF_LOCAL_KEY],
-            config_entry[CONF_PROTOCOL_VERSION],
+            float(config_entry[CONF_PROTOCOL_VERSION]),
         )
         for entity in config_entry[CONF_ENTITIES]:
             # this has to be done in case the device type is type_0d

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_FRIENDLY_NAME,
     CONF_PLATFORM,
-    CONF_SWITCHES,
 )
 import homeassistant.helpers.config_validation as cv
 
@@ -97,7 +96,6 @@ def schema_defaults(schema, dps_list=None, **defaults):
 
         if field.schema in defaults:
             field.default = vol.default_factory(defaults[field])
-
     return copy
 
 
@@ -310,37 +308,21 @@ class LocaltuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle import from YAML."""
 
         def _convert_entity(conf):
-            converted = {
-                CONF_ID: conf[CONF_ID],
-                CONF_FRIENDLY_NAME: conf[CONF_FRIENDLY_NAME],
-                CONF_PLATFORM: self.platform,
-            }
-            for field in flow_schema(self.platform, self.dps_strings).keys():
-                converted[str(field)] = conf[field]
-            return converted
+            for field in flow_schema(conf[CONF_PLATFORM], self.dps_strings).keys():
+                if str(field) in conf:
+                    conf[str(field)] = str(conf[field])
 
         await self.async_set_unique_id(user_input[CONF_DEVICE_ID])
-        self.platform = user_input[CONF_PLATFORM]
 
-        if len(user_input.get(CONF_SWITCHES, [])) > 0:
-            for switch_conf in user_input[CONF_SWITCHES].values():
-                self.entities.append(_convert_entity(switch_conf))
-        else:
-            self.entities.append(_convert_entity(user_input))
+        for entity_conf in user_input[CONF_ENTITIES]:
+            entity_conf[CONF_ID] = str(entity_conf[CONF_ID])
+            _convert_entity(entity_conf)
 
-        # print('ENTITIES: [{}] '.format(self.entities))
-        config = {
-            CONF_FRIENDLY_NAME: f"{user_input[CONF_FRIENDLY_NAME]}",
-            CONF_HOST: user_input[CONF_HOST],
-            CONF_DEVICE_ID: user_input[CONF_DEVICE_ID],
-            CONF_LOCAL_KEY: user_input[CONF_LOCAL_KEY],
-            CONF_PROTOCOL_VERSION: user_input[CONF_PROTOCOL_VERSION],
-            CONF_YAML_IMPORT: True,
-            CONF_ENTITIES: self.entities,
-        }
-        self._abort_if_unique_id_configured(updates=config)
+        user_input[CONF_YAML_IMPORT] = True
+
+        self._abort_if_unique_id_configured(updates=user_input)
         return self.async_create_entry(
-            title=f"{config[CONF_FRIENDLY_NAME]} (YAML)", data=config
+            title=f"{user_input[CONF_FRIENDLY_NAME]} (YAML)", data=user_input
         )
 
 

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -62,7 +62,7 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Required(CONF_DEVICE_ID): cv.string,
         vol.Required(CONF_LOCAL_KEY): cv.string,
         vol.Required(CONF_FRIENDLY_NAME): cv.string,
-        vol.Required(CONF_PROTOCOL_VERSION, default="3.3"): vol.Coerce(float),
+        vol.Required(CONF_PROTOCOL_VERSION, default="3.3"): vol.In(["3.1", "3.3"]),
     }
 )
 
@@ -132,7 +132,7 @@ def strip_dps_values(user_input, dps_strings):
     stripped = {}
     for field, value in user_input.items():
         if value in dps_strings:
-            stripped[field] = user_input[field].split(" ")[0]
+            stripped[field] = int(user_input[field].split(" ")[0])
         else:
             stripped[field] = user_input[field]
     return stripped
@@ -306,17 +306,7 @@ class LocaltuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, user_input):
         """Handle import from YAML."""
-
-        def _convert_entity(conf):
-            for field in flow_schema(conf[CONF_PLATFORM], self.dps_strings).keys():
-                if str(field) in conf:
-                    conf[str(field)] = str(conf[field])
-
         await self.async_set_unique_id(user_input[CONF_DEVICE_ID])
-
-        for entity_conf in user_input[CONF_ENTITIES]:
-            entity_conf[CONF_ID] = str(entity_conf[CONF_ID])
-            _convert_entity(entity_conf)
 
         user_input[CONF_YAML_IMPORT] = True
 

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -26,3 +26,5 @@ DOMAIN = "localtuya"
 
 # Platforms in this list must support config flows
 PLATFORMS = ["binary_sensor", "cover", "fan", "light", "sensor", "switch"]
+
+TUYA_DEVICE = "tuya_device"

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -31,17 +31,14 @@ from homeassistant.components.cover import (
     SUPPORT_STOP,
     SUPPORT_SET_POSITION,
 )
-from homeassistant.const import (
-    CONF_ID,
-    CONF_FRIENDLY_NAME,
-)
+from homeassistant.const import CONF_ID
 
 from .const import (
     CONF_OPEN_CMD,
     CONF_CLOSE_CMD,
     CONF_STOP_CMD,
 )
-from .common import LocalTuyaEntity, TuyaDevice, prepare_setup_entities
+from .common import LocalTuyaEntity, prepare_setup_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +58,9 @@ def flow_schema(dps):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a Tuya cover based on a config entry."""
-    tuyainterface, entities_to_setup = prepare_setup_entities(config_entry, DOMAIN)
+    tuyainterface, entities_to_setup = prepare_setup_entities(
+        hass, config_entry, DOMAIN
+    )
     if not entities_to_setup:
         return
 
@@ -69,7 +68,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for device_config in entities_to_setup:
         covers.append(
             LocaltuyaCover(
-                TuyaDevice(tuyainterface, config_entry.data[CONF_FRIENDLY_NAME]),
+                tuyainterface,
                 config_entry,
                 device_config[CONF_ID],
             )
@@ -185,7 +184,7 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        _LOGGER.debug("Laudebugching command %s to cover ", self._config[CONF_STOP_CMD])
+        _LOGGER.debug("Launching command %s to cover ", self._config[CONF_STOP_CMD])
         self._device.set_dps(self._config[CONF_STOP_CMD], self._dps_id)
 
     def status_updated(self):

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -26,7 +26,6 @@ import voluptuous as vol
 from homeassistant.components.cover import (
     CoverEntity,
     DOMAIN,
-    PLATFORM_SCHEMA,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_STOP,
@@ -36,9 +35,7 @@ from homeassistant.const import (
     CONF_ID,
     CONF_FRIENDLY_NAME,
 )
-import homeassistant.helpers.config_validation as cv
 
-from . import BASE_PLATFORM_SCHEMA, import_from_yaml
 from .const import (
     CONF_OPEN_CMD,
     CONF_CLOSE_CMD,
@@ -51,15 +48,6 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_OPEN_CMD = "on"
 DEFAULT_CLOSE_CMD = "off"
 DEFAULT_STOP_CMD = "stop"
-
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(BASE_PLATFORM_SCHEMA).extend(
-    {
-        vol.Optional(CONF_OPEN_CMD, default=DEFAULT_OPEN_CMD): cv.string,
-        vol.Optional(CONF_CLOSE_CMD, default=DEFAULT_CLOSE_CMD): cv.string,
-        vol.Optional(CONF_STOP_CMD, default=DEFAULT_STOP_CMD): cv.string,
-    }
-)
 
 
 def flow_schema(dps):
@@ -88,11 +76,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
 
     async_add_entities(covers, True)
-
-
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up of the Tuya cover."""
-    return import_from_yaml(hass, config, DOMAIN)
 
 
 class LocaltuyaCover(LocalTuyaEntity, CoverEntity):

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -1,23 +1,4 @@
-"""
-Simple platform to locally control Tuya-based cover devices.
-
-Sample config yaml:
-
-cover:
-  - platform: localtuya #REQUIRED
-    host: 192.168.0.123 #REQUIRED
-    local_key: 1234567891234567 #REQUIRED
-    device_id: 123456789123456789abcd #REQUIRED
-    name: cover_guests #REQUIRED
-    friendly_name: Cover guests #REQUIRED
-    protocol_version: 3.3 #REQUIRED
-    id: 1 #OPTIONAL
-    icon: mdi:blinds #OPTIONAL
-    open_cmd: open #OPTIONAL, default is 'on'
-    close_cmd: close #OPTIONAL, default is 'off'
-    stop_cmd: stop #OPTIONAL, default is 'stop'
-
-"""
+"""Platform to locally control Tuya-based cover devices."""
 import logging
 from time import sleep
 

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -26,9 +26,9 @@ from homeassistant.components.fan import (
     SUPPORT_SET_SPEED,
     SUPPORT_OSCILLATE,
 )
-from homeassistant.const import CONF_ID, CONF_FRIENDLY_NAME
+from homeassistant.const import CONF_ID
 
-from .common import LocalTuyaEntity, TuyaDevice, prepare_setup_entities
+from .common import LocalTuyaEntity, prepare_setup_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,9 @@ def flow_schema(dps):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a Tuya fan based on a config entry."""
-    tuyainterface, entities_to_setup = prepare_setup_entities(config_entry, DOMAIN)
+    tuyainterface, entities_to_setup = prepare_setup_entities(
+        hass, config_entry, DOMAIN
+    )
     if not entities_to_setup:
         return
 
@@ -49,7 +51,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for device_config in entities_to_setup:
         fans.append(
             LocaltuyaFan(
-                TuyaDevice(tuyainterface, config_entry.data[CONF_FRIENDLY_NAME]),
+                tuyainterface,
                 config_entry,
                 device_config[CONF_ID],
             )

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -1,19 +1,4 @@
-"""
-Simple platform to control LOCALLY Tuya cover devices.
-
-Sample config yaml
-
-fan:
-  - platform: localtuya
-    host: 192.168.0.123
-    local_key: 1234567891234567
-    device_id: 123456789123456789abcd
-    name: fan guests
-    friendly_name: fan guests
-    protocol_version: 3.3
-    id: 1
-
-"""
+"""Platform to locally control Tuya-based fan devices."""
 import logging
 
 from homeassistant.components.fan import (

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -19,7 +19,6 @@ import logging
 from homeassistant.components.fan import (
     FanEntity,
     DOMAIN,
-    PLATFORM_SCHEMA,
     SPEED_OFF,
     SPEED_LOW,
     SPEED_MEDIUM,
@@ -29,15 +28,9 @@ from homeassistant.components.fan import (
 )
 from homeassistant.const import CONF_ID, CONF_FRIENDLY_NAME
 
-from . import (
-    BASE_PLATFORM_SCHEMA,
-    import_from_yaml,
-)
 from .common import LocalTuyaEntity, TuyaDevice, prepare_setup_entities
 
 _LOGGER = logging.getLogger(__name__)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(BASE_PLATFORM_SCHEMA)
 
 
 def flow_schema(dps):
@@ -63,11 +56,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
 
     async_add_entities(fans, True)
-
-
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up of the Tuya fan."""
-    return import_from_yaml(hass, config, DOMAIN)
 
 
 class LocaltuyaFan(LocalTuyaEntity, FanEntity):

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -1,16 +1,4 @@
-"""
-Simple platform to control LOCALLY Tuya light devices.
-
-Sample config yaml
-
-light:
-  - platform: localtuya
-    host: 192.168.0.1
-    local_key: 1234567891234567
-    device_id: 12345678912345671234
-    friendly_name: This Light
-    protocol_version: 3.3
-"""
+"""Platform to locally control Tuya-based light devices."""
 import logging
 
 from homeassistant.const import CONF_ID

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -13,10 +13,7 @@ light:
 """
 import logging
 
-from homeassistant.const import (
-    CONF_ID,
-    CONF_FRIENDLY_NAME,
-)
+from homeassistant.const import CONF_ID
 from homeassistant.components.light import (
     LightEntity,
     DOMAIN,
@@ -27,7 +24,7 @@ from homeassistant.components.light import (
     SUPPORT_COLOR,
 )
 
-from .common import LocalTuyaEntity, TuyaDevice, prepare_setup_entities
+from .common import LocalTuyaEntity, prepare_setup_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,18 +46,17 @@ def flow_schema(dps):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a Tuya light based on a config entry."""
-    tuyainterface, entities_to_setup = prepare_setup_entities(config_entry, DOMAIN)
+    tuyainterface, entities_to_setup = prepare_setup_entities(
+        hass, config_entry, DOMAIN
+    )
     if not entities_to_setup:
         return
 
     lights = []
     for device_config in entities_to_setup:
-        # this has to be done in case the device type is type_0d
-        tuyainterface.add_dps_to_request(device_config[CONF_ID])
-
         lights.append(
             LocaltuyaLight(
-                TuyaDevice(tuyainterface, config_entry.data[CONF_FRIENDLY_NAME]),
+                tuyainterface,
                 config_entry,
                 device_config[CONF_ID],
             )

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
 from homeassistant.components.light import (
     LightEntity,
     DOMAIN,
-    PLATFORM_SCHEMA,
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
@@ -28,12 +27,7 @@ from homeassistant.components.light import (
     SUPPORT_COLOR,
 )
 
-from . import (
-    BASE_PLATFORM_SCHEMA,
-    import_from_yaml,
-)
 from .common import LocalTuyaEntity, TuyaDevice, prepare_setup_entities
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,8 +40,6 @@ DPS_INDEX_MODE = "2"
 DPS_INDEX_BRIGHTNESS = "3"
 DPS_INDEX_COLOURTEMP = "4"
 DPS_INDEX_COLOUR = "5"
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(BASE_PLATFORM_SCHEMA)
 
 
 def flow_schema(dps):
@@ -75,11 +67,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
 
     async_add_entities(lights, True)
-
-
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up of the Tuya light."""
-    return import_from_yaml(hass, config, DOMAIN)
 
 
 class LocaltuyaLight(LocalTuyaEntity, LightEntity):

--- a/custom_components/localtuya/sensor.py
+++ b/custom_components/localtuya/sensor.py
@@ -1,19 +1,4 @@
-"""
-Platform to prsent any Tuya DP as a sensor.
-
-Sample config yaml
-
-sensor:
-  - platform: localtuya
-    host: 192.168.0.1
-    local_key: 1234567891234567
-    device_id: 12345678912345671234
-    friendly_name: Current
-    protocol_version: 3.3
-    id: 18
-    unit_of_measurement: mA
-    device_class: current
-"""
+"""Platform to present any Tuya DP as a sensor."""
 import logging
 
 import voluptuous as vol

--- a/custom_components/localtuya/sensor.py
+++ b/custom_components/localtuya/sensor.py
@@ -17,6 +17,7 @@ from .common import LocalTuyaEntity, prepare_setup_entities
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_SCALING = 1.0
+DEFAULT_PRECISION = 2
 
 
 def flow_schema(dps):
@@ -68,9 +69,6 @@ class LocaltuyaSensor(LocalTuyaEntity):
     @property
     def state(self):
         """Return sensor state."""
-        scale_factor = self._config.get(CONF_SCALING)
-        if scale_factor is not None:
-            return self._state * scale_factor
         return self._state
 
     @property
@@ -85,4 +83,8 @@ class LocaltuyaSensor(LocalTuyaEntity):
 
     def status_updated(self):
         """Device status was updated."""
-        self._state = self.dps(self._dps_id)
+        state = self.dps(self._dps_id)
+        scale_factor = self._config.get(CONF_SCALING)
+        if scale_factor is not None:
+            state = round(state * scale_factor, DEFAULT_PRECISION)
+        self._state = state

--- a/custom_components/localtuya/sensor.py
+++ b/custom_components/localtuya/sensor.py
@@ -18,7 +18,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import DOMAIN, PLATFORM_SCHEMA, DEVICE_CLASSES
+from homeassistant.components.sensor import DOMAIN, DEVICE_CLASSES
 from homeassistant.const import (
     CONF_ID,
     CONF_DEVICE_CLASS,
@@ -27,18 +27,12 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 
-from . import (
-    BASE_PLATFORM_SCHEMA,
-    import_from_yaml,
-)
 from .const import CONF_SCALING
 from .common import LocalTuyaEntity, TuyaDevice, prepare_setup_entities
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_SCALING = 1.0
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(BASE_PLATFORM_SCHEMA)
 
 
 def flow_schema(dps):
@@ -69,11 +63,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
 
     async_add_entities(sensors, True)
-
-
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up of the Tuya sensor."""
-    return import_from_yaml(hass, config, DOMAIN)
 
 
 class LocaltuyaSensor(LocalTuyaEntity):

--- a/custom_components/localtuya/sensor.py
+++ b/custom_components/localtuya/sensor.py
@@ -22,13 +22,12 @@ from homeassistant.components.sensor import DOMAIN, DEVICE_CLASSES
 from homeassistant.const import (
     CONF_ID,
     CONF_DEVICE_CLASS,
-    CONF_FRIENDLY_NAME,
     CONF_UNIT_OF_MEASUREMENT,
     STATE_UNKNOWN,
 )
 
 from .const import CONF_SCALING
-from .common import LocalTuyaEntity, TuyaDevice, prepare_setup_entities
+from .common import LocalTuyaEntity, prepare_setup_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +47,9 @@ def flow_schema(dps):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a Tuya sensor based on a config entry."""
-    tuyainterface, entities_to_setup = prepare_setup_entities(config_entry, DOMAIN)
+    tuyainterface, entities_to_setup = prepare_setup_entities(
+        hass, config_entry, DOMAIN
+    )
     if not entities_to_setup:
         return
 
@@ -56,7 +57,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     for device_config in entities_to_setup:
         sensors.append(
             LocaltuyaSensor(
-                TuyaDevice(tuyainterface, config_entry.data[CONF_FRIENDLY_NAME]),
+                tuyainterface,
                 config_entry,
                 device_config[CONF_ID],
             )

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -1,29 +1,4 @@
-"""
-Simple platform to control LOCALLY Tuya switch devices.
-
-Sample config yaml
-
-switch:
-  - platform: localtuya
-    host: 192.168.0.1
-    local_key: 1234567891234567
-    device_id: 12345678912345671234
-    name: tuya_01
-    friendly_name: tuya_01
-    protocol_version: 3.3
-    switches:
-      sw01:
-        name: main_plug
-        friendly_name: Main Plug
-        id: 1
-        current: 18
-        current_consumption: 19
-        voltage: 20
-      sw02:
-        name: usb_plug
-        friendly_name: USB Plug
-        id: 7
-"""
+"""Platform to locally control Tuya-based switch devices."""
 import logging
 
 import voluptuous as vol

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -32,10 +32,7 @@ from homeassistant.components.switch import (
     SwitchEntity,
     DOMAIN,
 )
-from homeassistant.const import (
-    CONF_ID,
-    CONF_FRIENDLY_NAME,
-)
+from homeassistant.const import CONF_ID
 
 from .const import (
     ATTR_CURRENT,
@@ -45,11 +42,9 @@ from .const import (
     CONF_CURRENT_CONSUMPTION,
     CONF_VOLTAGE,
 )
-from .common import LocalTuyaEntity, TuyaDevice, prepare_setup_entities
+from .common import LocalTuyaEntity, prepare_setup_entities
 
 _LOGGER = logging.getLogger(__name__)
-
-DEFAULT_ID = "1"
 
 
 def flow_schema(dps):
@@ -63,24 +58,17 @@ def flow_schema(dps):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a Tuya switch based on a config entry."""
-    tuyainterface, entities_to_setup = prepare_setup_entities(config_entry, DOMAIN)
+    tuyainterface, entities_to_setup = prepare_setup_entities(
+        hass, config_entry, DOMAIN
+    )
     if not entities_to_setup:
         return
 
     switches = []
     for device_config in entities_to_setup:
-        if device_config.get(CONF_CURRENT, "-1") != "-1":
-            tuyainterface.add_dps_to_request(device_config.get(CONF_CURRENT))
-        if device_config.get(CONF_CURRENT_CONSUMPTION, "-1") != "-1":
-            tuyainterface.add_dps_to_request(
-                device_config.get(CONF_CURRENT_CONSUMPTION)
-            )
-        if device_config.get(CONF_VOLTAGE, "-1") != "-1":
-            tuyainterface.add_dps_to_request(device_config.get(CONF_VOLTAGE))
-
         switches.append(
             LocaltuyaSwitch(
-                TuyaDevice(tuyainterface, config_entry.data[CONF_FRIENDLY_NAME]),
+                tuyainterface,
                 config_entry,
                 device_config[CONF_ID],
             )

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -31,20 +31,12 @@ import voluptuous as vol
 from homeassistant.components.switch import (
     SwitchEntity,
     DOMAIN,
-    PLATFORM_SCHEMA,
 )
 from homeassistant.const import (
     CONF_ID,
-    CONF_SWITCHES,
     CONF_FRIENDLY_NAME,
-    CONF_NAME,
 )
-import homeassistant.helpers.config_validation as cv
 
-from . import (
-    BASE_PLATFORM_SCHEMA,
-    import_from_yaml,
-)
 from .const import (
     ATTR_CURRENT,
     ATTR_CURRENT_CONSUMPTION,
@@ -58,27 +50,6 @@ from .common import LocalTuyaEntity, TuyaDevice, prepare_setup_entities
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_ID = "1"
-
-# TODO: This will eventully merge with flow_schema
-SWITCH_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_ID, default=DEFAULT_ID): cv.string,
-        vol.Optional(CONF_NAME): cv.string,  # Deprecated: not used
-        vol.Required(CONF_FRIENDLY_NAME): cv.string,
-        vol.Optional(CONF_CURRENT, default="-1"): cv.string,
-        vol.Optional(CONF_CURRENT_CONSUMPTION, default="-1"): cv.string,
-        vol.Optional(CONF_VOLTAGE, default="-1"): cv.string,
-    }
-)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(BASE_PLATFORM_SCHEMA).extend(
-    {
-        vol.Optional(CONF_CURRENT, default="-1"): cv.string,
-        vol.Optional(CONF_CURRENT_CONSUMPTION, default="-1"): cv.string,
-        vol.Optional(CONF_VOLTAGE, default="-1"): cv.string,
-        vol.Optional(CONF_SWITCHES, default={}): vol.Schema({cv.slug: SWITCH_SCHEMA}),
-    }
-)
 
 
 def flow_schema(dps):
@@ -116,11 +87,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         )
 
     async_add_entities(switches, True)
-
-
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up of the Tuya switch."""
-    return import_from_yaml(hass, config, DOMAIN)
 
 
 class LocaltuyaSwitch(LocalTuyaEntity, SwitchEntity):


### PR DESCRIPTION
Basically #40. Instead of setting up devices via platforms (e.g. `switch: ... platform: localtuya`), we now set up it up via the component (`localtuya:`).

One "device" object (pytuya) is also set up per device instead of one per entity.