### PR TITLE
Updating the status of TuyaDevice using the response of the set_dps() call

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -92,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up LocalTuya integration from a config entry."""
     unsub_listener = entry.add_update_listener(update_listener)
 
-    device = TuyaDevice(entry.data)
+    device = TuyaDevice(hass, entry.data)
 
     async def update_state(now):
         """Read device status and update platforms."""

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -89,7 +89,7 @@ class TuyaDevice:
                     raise ConnectionError("Failed to update status .")
 
     def set_dps(self, state, dps_index):
-        """Changes the value of a DP of the Tuya device, and update the cached status."""
+        """Change the value of a DP of the Tuya device, and update the cached status."""
         # _LOGGER.info("running def set_dps from TuyaDevice")
         # No need to clear the cache here: let's just update the status of the 
         # changed dps as returned by the interface (see 5 lines below)

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -91,7 +91,7 @@ class TuyaDevice:
     def set_dps(self, state, dps_index):
         """Change value of a DP of the Tuya device and update the cached status."""
         # _LOGGER.info("running def set_dps from TuyaDevice")
-        # No need to clear the cache here: let's just update the status of the 
+        # No need to clear the cache here: let's just update the status of the
         # changed dps as returned by the interface (see 5 lines below)
         # self._cached_status = ""
         # self._cached_status_time = 0
@@ -99,7 +99,7 @@ class TuyaDevice:
             try:
                 result = self._interface.set_dps(state, dps_index)
                 self._cached_status["dps"].update(result["dps"])
-                # NOW WE SHOULD TRIGGER status_updated FOR ALL ENTITIES 
+                # NOW WE SHOULD TRIGGER status_updated FOR ALL ENTITIES
                 # INVOLVED IN result["dps"] :
                 # for dp in result["dps"]:
                 #    have status_updated() called....

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -89,7 +89,7 @@ class TuyaDevice:
                     raise ConnectionError("Failed to update status .")
 
     def set_dps(self, state, dps_index):
-        """Change the value of a DP of the Tuya device, and update the cached status."""
+        """Change value of a DP of the Tuya device and update the cached status."""
         # _LOGGER.info("running def set_dps from TuyaDevice")
         # No need to clear the cache here: let's just update the status of the 
         # changed dps as returned by the interface (see 5 lines below)

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -91,15 +91,17 @@ class TuyaDevice:
     def set_dps(self, state, dps_index):
         """Changes the value of a DP of the Tuya device, and update the cached status."""
         # _LOGGER.info("running def set_dps from TuyaDevice")
-        # No need to clear the cache here: let's just update the status of the changed dps as returned by the interface (see 5 lines below)
-#        self._cached_status = ""
-#        self._cached_status_time = 0
+        # No need to clear the cache here: let's just update the status of the 
+        # changed dps as returned by the interface (see 5 lines below)
+        # self._cached_status = ""
+        # self._cached_status_time = 0
         for i in range(5):
             try:
                 result = self._interface.set_dps(state, dps_index)
                 self._cached_status["dps"].update(result["dps"])
-                # NOW WE SHOULD TRIGGER status_updated FOR ALL ENTITIES INVOLVED IN result["dps"] :
-                #for dp in result["dps"]:
+                # NOW WE SHOULD TRIGGER status_updated FOR ALL ENTITIES 
+                # INVOLVED IN result["dps"] :
+                # for dp in result["dps"]:
                 #    have status_updated() called....
                 return
             except Exception:

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -89,6 +89,7 @@ class TuyaDevice:
                     raise ConnectionError("Failed to update status .")
 
     def set_dps(self, state, dps_index):
+        """Changes the value of a DP of the Tuya device, and update the cached status."""
         # _LOGGER.info("running def set_dps from TuyaDevice")
         # No need to clear the cache here: let's just update the status of the changed dps as returned by the interface (see 5 lines below)
 #        self._cached_status = ""
@@ -116,7 +117,7 @@ class TuyaDevice:
     #                    raise ConnectionError("Failed to set status.")
 
     def status(self):
-        """Get state of Tuya switch and cache the results."""
+        """Get the state of the Tuya device and cache the results."""
         _LOGGER.debug("running def status(self) from TuyaDevice")
         self._lock.acquire()
         try:

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -89,13 +89,18 @@ class TuyaDevice:
                     raise ConnectionError("Failed to update status .")
 
     def set_dps(self, state, dps_index):
-        # _LOGGER.info("running def set_dps from cover")
-        """Change the Tuya switch status and clear the cache."""
-        self._cached_status = ""
-        self._cached_status_time = 0
+        # _LOGGER.info("running def set_dps from TuyaDevice")
+        # No need to clear the cache here: let's just update the status of the changed dps as returned by the interface (see 5 lines below)
+#        self._cached_status = ""
+#        self._cached_status_time = 0
         for i in range(5):
             try:
-                return self._interface.set_dps(state, dps_index)
+                result = self._interface.set_dps(state, dps_index)
+                self._cached_status["dps"].update(result["dps"])
+                # NOW WE SHOULD TRIGGER status_updated FOR ALL ENTITIES INVOLVED IN result["dps"] :
+                #for dp in result["dps"]:
+                #    have status_updated() called....
+                return
             except Exception:
                 print(
                     "Failed to set status of device [{}]".format(
@@ -116,7 +121,7 @@ class TuyaDevice:
         self._lock.acquire()
         try:
             now = time()
-            if not self._cached_status or now - self._cached_status_time > 15:
+            if not self._cached_status or now - self._cached_status_time > 10:
                 sleep(0.5)
                 self._cached_status = self.__get_status()
                 self._cached_status_time = time()

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -253,10 +253,10 @@ class TuyaInterface:
         """
         return self.exchange(SET, {str(dps_index): value})
 
-
     def _decode_received_data(self, data, is_status):
-        """Return device status."""
-        """is_status may be True (result of a status request) or False (result of a set_dps request)"""
+        """decode the response data received from the device"""
+        # is_status may be True (result of a status request) 
+        # or False (result of a set_dps request)
         result = data[20:-8]  # hard coded offsets
         if self.dev_type != "type_0a":
             result = result[15:]
@@ -283,7 +283,7 @@ class TuyaInterface:
             result = result[16:]
             cipher = AESCipher(self.local_key)
             result = cipher.decrypt(result)
-            #print("decrypted result=[{}]".format(result))
+            # print("decrypted result=[{}]".format(result))
             log.info("decrypted result=%r", result)
             if not isinstance(result, str):
                 result = result.decode()
@@ -307,7 +307,6 @@ class TuyaInterface:
             log.error("Unexpected status() payload=%r", result)
 
         return result
-
 
     def detect_available_dps(self):
         """Return which datapoints are supported by the device."""

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -253,61 +253,6 @@ class TuyaInterface:
         """
         return self.exchange(SET, {str(dps_index): value})
 
-    def _decode_received_data(self, data, is_status):
-        """Decode the response data received from the device."""
-        # is_status may be True (result of a status request)
-        # or False (result of a set_dps request)
-        result = data[20:-8]  # hard coded offsets
-        if self.dev_type != "type_0a":
-            result = result[15:]
-        elif not is_status:
-            result = result[15:]
-
-        log.debug("Decrypting %r :", result)
-        # result = data[data.find('{'):data.rfind('}')+1]  # naive marker search,
-        # hope neither { nor } occur in header/footer
-        # print('result %r' % result)
-        if result.startswith(b"{"):
-            # this is the regular expected code path
-            if not isinstance(result, str):
-                result = result.decode()
-            result = json.loads(result)
-        elif result.startswith(PROTOCOL_VERSION_BYTES_31):
-            # got an encrypted payload, happens occasionally
-            # expect resulting json to look similar to:
-            #   {"devId":"ID","dps":{"1":true,"2":0},"t":EPOCH_SECS,"s":3_DIGIT_NUM}
-            # NOTE dps.2 may or may not be present
-            result = result[len(PROTOCOL_VERSION_BYTES_31) :]  # remove version header
-            # remove (what I'm guessing, but not confirmed is) 16-bytes of MD5
-            # hexdigest of payload
-            result = result[16:]
-            cipher = AESCipher(self.local_key)
-            result = cipher.decrypt(result)
-            # print("decrypted result=[{}]".format(result))
-            log.info("decrypted result=%r", result)
-            if not isinstance(result, str):
-                result = result.decode()
-            result = json.loads(result)
-        elif self.version == 3.3:
-            # results of a set_dps request must have a further offset
-            cipher = AESCipher(self.local_key)
-            result = cipher.decrypt(result, False)
-            log.debug("decrypted result=%r", result)
-            if "data unvalid" in result:
-                self.dev_type = "type_0d"
-                log.info(
-                    "'data unvalid' error detected: switching to dev_type %r",
-                    self.dev_type,
-                )
-                return self.status()
-            if not isinstance(result, str):
-                result = result.decode()
-            result = json.loads(result)
-        else:
-            log.error("Unexpected status() payload=%r", result)
-
-        return result
-
     def detect_available_dps(self):
         """Return which datapoints are supported by the device."""
         # type_0d devices need a sort of bruteforce querying in order to detect the

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -255,7 +255,7 @@ class TuyaInterface:
 
     def _decode_received_data(self, data, is_status):
         """Decode the response data received from the device."""
-        # is_status may be True (result of a status request) 
+        # is_status may be True (result of a status request)
         # or False (result of a set_dps request)
         result = data[20:-8]  # hard coded offsets
         if self.dev_type != "type_0a":

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -254,7 +254,7 @@ class TuyaInterface:
         return self.exchange(SET, {str(dps_index): value})
 
     def _decode_received_data(self, data, is_status):
-        """decode the response data received from the device"""
+        """Decode the response data received from the device."""
         # is_status may be True (result of a status request) 
         # or False (result of a set_dps request)
         result = data[20:-8]  # hard coded offsets


### PR DESCRIPTION
Optimizing the set_dps calls.
With previous implementation, `TuyaDevice.set_dps()` just clears the cached status, resulting in a delay before having the status updated.

Actually, the call returns a json with the new status of the changed DPs, such as:
`{'devId': 'xxxxxx', 'dps': {'7': False}}`
This PR introduces (and fixes) the decryption of the response of the `TuyaInterface.set_dps()` call, and uses the returned JSON to update the TuyaDevice cached status.

TODO ( @postlund please help):
once the cached status is updated, we probably need to call the `status_updated()` method for each entity involved, right? Which is the best way to do this? I don't know whether it's better to dispatch a signal, or to call the methods directly, or whatever.
BTW, I think the involved entity should be just the one that triggered the set_dps (at least, it's what happens for switches and covers) but I also think we'd better keep it general.
PS, I've tried to do this by defining a `set_dps()` method in `LocalTuyaEntity` class and having it called by the platform instead of the interface's one but it doesn't work, or at least it doesn't solve the bug mentioned in #51.