### PR TITLE
Add optional dps for switches and covers to the dps_to_request list

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -88,10 +88,15 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
     ):
         """Initialize a new LocaltuyaCover."""
         super().__init__(device, config_entry, switchid, **kwargs)
+
         self._state = None
         self._current_cover_position = None
         self._open_cmd = self._config[CONF_OPENCLOSE_CMDS].split("_")[0]
         self._close_cmd = self._config[CONF_OPENCLOSE_CMDS].split("_")[1]
+        if self.has_config(CONF_CURRENT_POSITION_DP):
+            device._interface.add_dps_to_request(self._config[CONF_CURRENT_POSITION_DP])
+        if self.has_config(CONF_SET_POSITION_DP):
+            device._interface.add_dps_to_request(self._config[CONF_SET_POSITION_DP])
         print("Initialized cover [{}]".format(self.name))
 
     @property

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -64,6 +64,13 @@ class LocaltuyaSwitch(LocalTuyaEntity, SwitchEntity):
     ):
         """Initialize the Tuya switch."""
         super().__init__(device, config_entry, switchid, **kwargs)
+
+        if self.has_config(CONF_VOLTAGE):
+            device._interface.add_dps_to_request(self._config[CONF_VOLTAGE])
+        if self.has_config(CONF_CURRENT):
+            device._interface.add_dps_to_request(self._config[CONF_CURRENT])
+        if self.has_config(CONF_CURRENT_CONSUMPTION):
+            device._interface.add_dps_to_request(self._config[CONF_CURRENT_CONSUMPTION])
         self._state = None
         print("Initialized switch [{}]".format(self.name))
 


### PR DESCRIPTION
Added optional DPs (current/voltage, set/get Cover Position...) to the list of dps to request, for demanding 0d type devices.