### PR TITLE
Re-map light brightness range

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -34,6 +34,8 @@ localtuya:
         friendly_name: Device Light
         id: 4
         brightness: 20
+        brightness_lower: 29 # Optional
+        brightness_upper: 1000 # Optional
         color_temp: 21
 
       - platform: sensor

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -8,6 +8,10 @@ CONF_LOCAL_KEY = "local_key"
 CONF_PROTOCOL_VERSION = "protocol_version"
 CONF_DPS_STRINGS = "dps_strings"
 
+# light
+CONF_BRIGHTNESS_LOWER = "brightness_lower"
+CONF_BRIGHTNESS_UPPER = "brightness_upper"
+
 # switch
 CONF_CURRENT = "current"
 CONF_CURRENT_CONSUMPTION = "current_consumption"

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -89,6 +89,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         """Return the color_temp of the light."""
         if self.has_config(CONF_COLOR_TEMP):
             return int(MAX_MIRED - (((MAX_MIRED - MIN_MIRED) / 255) * self._color_temp))
+        return None
 
     @property
     def min_mireds(self):

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -35,7 +35,7 @@ def map_range(value, from_lower, from_upper, to_lower, to_upper):
     mapped = (value - from_lower) * (to_upper - to_lower) / (
         from_upper - from_lower
     ) + to_lower
-    return int(min(max(mapped, to_lower), to_upper))
+    return round(min(max(mapped, to_lower), to_upper))
 
 
 def flow_schema(dps):
@@ -112,7 +112,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn on or control the light."""
-        self._device.set_dp(True, self._dp_id)
+        await self._device.set_dp(True, self._dp_id)
         features = self.supported_features
 
         if ATTR_BRIGHTNESS in kwargs and (features & SUPPORT_BRIGHTNESS):
@@ -123,7 +123,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 self._lower_brightness,
                 self._upper_brightness,
             )
-            self._device.set_dp(brightness, self._config.get(CONF_BRIGHTNESS))
+            await self._device.set_dp(brightness, self._config.get(CONF_BRIGHTNESS))
 
         if ATTR_HS_COLOR in kwargs:
             raise ValueError(" TODO implement RGB from HS")

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -57,6 +57,8 @@
                     "state_on": "On Value",
                     "state_off": "Off Value",
                     "brightness": "Brightness",
+                    "brightness_lower": "Brightness Lower Value",
+                    "brightness_upper": "Brightness Upper Value",
                     "color_temp": "Color Temperature"
                 }
             }
@@ -94,6 +96,8 @@
                     "state_on": "On Value",
                     "state_off": "Off Value",
                     "brightness": "Brightness",
+                    "brightness_lower": "Brightness Lower Value",
+                    "brightness_upper": "Brightness Upper Value",
                     "color_temp": "Color Temperature"
                 }
             },


### PR DESCRIPTION
Home Assistant uses brightness range 0-255 whilst Tuya somewhere around
29-1092. This commit maps brightness between these two ranges.