### PR TITLE
Fix naming of set_dps in pytuya

### DIFF
--- a/custom_components/localtuya/binary_sensor.py
+++ b/custom_components/localtuya/binary_sensor.py
@@ -54,7 +54,7 @@ class LocaltuyaBinarySensor(LocalTuyaEntity, BinarySensorEntity):
 
     def status_updated(self):
         """Device status was updated."""
-        state = str(self.dps(self._dps_id)).lower()
+        state = str(self.dps(self._dp_id)).lower()
         if state == self._config[CONF_STATE_ON].lower():
             self._is_on = True
         elif state == self._config[CONF_STATE_OFF].lower():

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -83,12 +83,12 @@ def get_dps_for_platform(flow_schema):
             yield key.schema
 
 
-def get_entity_config(config_entry, dps_id):
+def get_entity_config(config_entry, dp_id):
     """Return entity config for a given DPS id."""
     for entity in config_entry.data[CONF_ENTITIES]:
-        if entity[CONF_ID] == dps_id:
+        if entity[CONF_ID] == dp_id:
             return entity
-    raise Exception(f"missing entity config for id {dps_id}")
+    raise Exception(f"missing entity config for id {dp_id}")
 
 
 class TuyaDevice(pytuya.TuyaListener):
@@ -171,13 +171,13 @@ class TuyaDevice(pytuya.TuyaListener):
         if self._interface:
             self._interface.close()
 
-    async def set_dps(self, state, dps_index):
+    async def set_dp(self, state, dp_index):
         """Change value of a DP of the Tuya device."""
         if self._interface is not None:
             try:
-                await self._interface.set_dps(state, dps_index)
+                await self._interface.set_dp(state, dp_index)
             except Exception:
-                _LOGGER.exception("Failed to set DP %d to %d", dps_index, state)
+                _LOGGER.exception("Failed to set DP %d to %d", dp_index, state)
         else:
             _LOGGER.error(
                 "Not connected to device %s", self._config_entry[CONF_FRIENDLY_NAME]
@@ -209,12 +209,12 @@ class TuyaDevice(pytuya.TuyaListener):
 class LocalTuyaEntity(Entity):
     """Representation of a Tuya entity."""
 
-    def __init__(self, device, config_entry, dps_id, **kwargs):
+    def __init__(self, device, config_entry, dp_id, **kwargs):
         """Initialize the Tuya entity."""
         self._device = device
         self._config_entry = config_entry
-        self._config = get_entity_config(config_entry, dps_id)
-        self._dps_id = dps_id
+        self._config = get_entity_config(config_entry, dp_id)
+        self._dp_id = dp_id
         self._status = {}
 
     async def async_added_to_hass(self):
@@ -263,7 +263,7 @@ class LocalTuyaEntity(Entity):
     @property
     def unique_id(self):
         """Return unique device identifier."""
-        return f"local_{self._config_entry.data[CONF_DEVICE_ID]}_{self._dps_id}"
+        return f"local_{self._config_entry.data[CONF_DEVICE_ID]}_{self._dp_id}"
 
     def has_config(self, attr):
         """Return if a config parameter has a valid value."""
@@ -273,16 +273,16 @@ class LocalTuyaEntity(Entity):
     @property
     def available(self):
         """Return if device is available or not."""
-        return str(self._dps_id) in self._status
+        return str(self._dp_id) in self._status
 
-    def dps(self, dps_index):
+    def dps(self, dp_index):
         """Return cached value for DPS index."""
-        value = self._status.get(str(dps_index))
+        value = self._status.get(str(dp_index))
         if value is None:
             _LOGGER.warning(
                 "Entity %s is requesting unknown DPS index %s",
                 self.entity_id,
-                dps_index,
+                dp_index,
             )
 
         return value

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -135,28 +135,28 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
         elif self._config[CONF_POSITIONING_MODE] == COVER_MODE_POSITION:
             converted_position = int(kwargs[ATTR_POSITION])
             if 0 <= converted_position <= 100 and self.has_config(CONF_SET_POSITION_DP):
-                await self._device.set_dps(
+                await self._device.set_dp(
                     converted_position, self._config[CONF_SET_POSITION_DP]
                 )
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
         _LOGGER.debug("Launching command %s to cover ", self._open_cmd)
-        await self._device.set_dps(self._open_cmd, self._dps_id)
+        await self._device.set_dp(self._open_cmd, self._dp_id)
 
     async def async_close_cover(self, **kwargs):
         """Close cover."""
         _LOGGER.debug("Launching command %s to cover ", self._close_cmd)
-        await self._device.set_dps(self._close_cmd, self._dps_id)
+        await self._device.set_dp(self._close_cmd, self._dp_id)
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
         _LOGGER.debug("Launching command %s to cover ", COVER_STOP_CMD)
-        await self._device.set_dps(COVER_STOP_CMD, self._dps_id)
+        await self._device.set_dp(COVER_STOP_CMD, self._dp_id)
 
     def status_updated(self):
         """Device status was updated."""
-        self._state = self.dps(self._dps_id)
+        self._state = self.dps(self._dp_id)
         if self.has_config(CONF_CURRENT_POSITION_DP):
             self._current_cover_position = self.dps(
                 self._config[CONF_CURRENT_POSITION_DP]

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -61,7 +61,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the entity."""
-        await self._device.set_dps(True, "1")
+        await self._device.set_dp(True, "1")
         if speed is not None:
             await self.async_set_speed(speed)
         else:
@@ -69,24 +69,24 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the entity."""
-        await self._device.set_dps(False, "1")
+        await self._device.set_dp(False, "1")
         self.schedule_update_ha_state()
 
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
         if speed == SPEED_OFF:
-            await self._device.set_dps(False, "1")
+            await self._device.set_dp(False, "1")
         elif speed == SPEED_LOW:
-            await self._device.set_dps("1", "2")
+            await self._device.set_dp("1", "2")
         elif speed == SPEED_MEDIUM:
-            await self._device.set_dps("2", "2")
+            await self._device.set_dp("2", "2")
         elif speed == SPEED_HIGH:
-            await self._device.set_dps("3", "2")
+            await self._device.set_dp("3", "2")
         self.schedule_update_ha_state()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation."""
-        await self._device.set_dps(oscillating, "8")
+        await self._device.set_dp(oscillating, "8")
         self.schedule_update_ha_state()
 
     @property

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -88,10 +88,10 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn on or control the light."""
-        await self._device.set_dps(True, self._dps_id)
+        await self._device.set_dp(True, self._dp_id)
 
         if ATTR_BRIGHTNESS in kwargs:
-            await self._device.set_dps(
+            await self._device.set_dp(
                 max(int(kwargs[ATTR_BRIGHTNESS]), 25), self._config.get(CONF_BRIGHTNESS)
             )
 
@@ -104,15 +104,15 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 - (255 / (MAX_MIRED - MIN_MIRED))
                 * (int(kwargs[ATTR_COLOR_TEMP]) - MIN_MIRED)
             )
-            await self._device.set_dps(color_temp, self._config.get(CONF_COLOR_TEMP))
+            await self._device.set_dp(color_temp, self._config.get(CONF_COLOR_TEMP))
 
     async def async_turn_off(self, **kwargs):
         """Turn Tuya light off."""
-        await self._device.set_dps(False, self._dps_id)
+        await self._device.set_dp(False, self._dp_id)
 
     def status_updated(self):
         """Device status was updated."""
-        self._state = self.dps(self._dps_id)
+        self._state = self.dps(self._dp_id)
 
         brightness = self.dps_conf(CONF_BRIGHTNESS)
         if brightness is not None:

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -21,9 +21,9 @@ Functions
    json = status()          # returns json payload
    set_version(version)     #  3.1 [default] or 3.3
    detect_available_dps()   # returns a list of available dps provided by the device
-   add_dps_to_request(dps_index)  # adds dps_index to the list of dps used by the
+   add_dps_to_request(dp_index)  # adds dp_index to the list of dps used by the
                                   # device (to be queried in the payload)
-   set_dps(on, dps_index)   # Set value of any dps index.
+   set_dp(on, dp_index)   # Set value of any dps index.
 
 
 Credits
@@ -420,15 +420,15 @@ class TuyaProtocol(asyncio.Protocol):
         """Send a heartbeat message."""
         return await self.exchange(HEARTBEAT)
 
-    async def set_dps(self, value, dps_index):
+    async def set_dp(self, value, dp_index):
         """
         Set value (may be any type: bool, int or string) of any dps index.
 
         Args:
-            dps_index(int):   dps index to set
+            dp_index(int):   dps index to set
             value: new value for the dps index
         """
-        return await self.exchange(SET, {str(dps_index): value})
+        return await self.exchange(SET, {str(dp_index): value})
 
     async def detect_available_dps(self):
         """Return which datapoints are supported by the device."""
@@ -457,12 +457,12 @@ class TuyaProtocol(asyncio.Protocol):
         self.log.debug("detected dps: %s", detected_dps)
         return detected_dps
 
-    def add_dps_to_request(self, dps_index):
+    def add_dps_to_request(self, dp_indicies):
         """Add a datapoint (DP) to be included in requests."""
-        if isinstance(dps_index, int):
-            self.dps_to_request[str(dps_index)] = None
+        if isinstance(dp_indicies, int):
+            self.dps_to_request[str(dp_indicies)] = None
         else:
-            self.dps_to_request.update({str(index): None for index in dps_index})
+            self.dps_to_request.update({str(index): None for index in dp_indicies})
 
     def _decode_payload(self, payload):
         self.log.debug("Decode payload: %s", payload)

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -430,6 +430,10 @@ class TuyaProtocol(asyncio.Protocol):
         """
         return await self.exchange(SET, {str(dp_index): value})
 
+    async def set_dps(self, value, dps):
+        """Set values for a set of datapoints."""
+        return await self.exchange(SET, dps)
+
     async def detect_available_dps(self):
         """Return which datapoints are supported by the device."""
         # type_0d devices need a sort of bruteforce querying in order to detect the

--- a/custom_components/localtuya/sensor.py
+++ b/custom_components/localtuya/sensor.py
@@ -62,7 +62,7 @@ class LocaltuyaSensor(LocalTuyaEntity):
 
     def status_updated(self):
         """Device status was updated."""
-        state = self.dps(self._dps_id)
+        state = self.dps(self._dp_id)
         scale_factor = self._config.get(CONF_SCALING)
         if scale_factor is not None:
             state = round(state * scale_factor, DEFAULT_PRECISION)

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -67,15 +67,15 @@ class LocaltuyaSwitch(LocalTuyaEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn Tuya switch on."""
-        await self._device.set_dps(True, self._dps_id)
+        await self._device.set_dp(True, self._dp_id)
 
     async def async_turn_off(self, **kwargs):
         """Turn Tuya switch off."""
-        await self._device.set_dps(False, self._dps_id)
+        await self._device.set_dp(False, self._dp_id)
 
     def status_updated(self):
         """Device status was updated."""
-        self._state = self.dps(self._dps_id)
+        self._state = self.dps(self._dp_id)
 
 
 async_setup_entry = partial(async_setup_entry, DOMAIN, LocaltuyaSwitch, flow_schema)


### PR DESCRIPTION
Renames `set_dps` to `set_dp` and introduces `set_dps` which can set multiple datapoints at once (needed for RGB support).