### PR TITLE
Allow defining the list of fan speed options

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -37,6 +37,7 @@ CONF_FAN_OSCILLATING_CONTROL = "fan_oscillating_control"
 CONF_FAN_SPEED_LOW = "fan_speed_low"
 CONF_FAN_SPEED_MEDIUM = "fan_speed_medium"
 CONF_FAN_SPEED_HIGH = "fan_speed_high"
+CONF_FAN_SPEED_LIST = "fan_speed_list"
 
 # sensor
 CONF_SCALING = "scaling"

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_FAN_SPEED_HIGH,
     CONF_FAN_SPEED_LOW,
     CONF_FAN_SPEED_MEDIUM,
+    CONF_FAN_SPEED_LIST,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,6 +41,7 @@ def flow_schema(dps):
         vol.Optional(CONF_FAN_SPEED_HIGH, default=SPEED_HIGH): vol.In(
             [SPEED_HIGH, "auto", "3", "4", "large", "big"]
         ),
+        vol.Optional(CONF_FAN_SPEED_LIST): vol.Schema([str]),
     }
 
 
@@ -77,6 +79,8 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
+        if self.has_config(CONF_FAN_SPEED_LIST):
+            return self._config.get(CONF_FAN_SPEED_LIST)
         return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
     async def async_turn_on(self, speed: str = None, **kwargs) -> None:


### PR DESCRIPTION
Some of the fan does not have 3 speed of `[SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]`.

This PR allows user to customise their fan speed list by
```yaml
       - platform: fan
         id: 1
         fan_speed_control: 2
         fan_speed_list: ["off", "foo", "bar"]
```