### PR TITLE
fix: check brightness is set before attempting to map the range #1057

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -185,7 +185,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
     @property
     def brightness(self):
         """Return the brightness of the light."""
-        if (self.is_color_mode or self.is_white_mode) and self._brightness:
+        if (self.is_color_mode or self.is_white_mode) and self._brightness is not None:
             return map_range(
                 self._brightness, self._lower_brightness, self._upper_brightness, 0, 255
             )


### PR DESCRIPTION
This fixes #1057, or at least my instance of the issue. 

It introduces a check to ensure the `self._brightness` property is set before trying to map it into the range. 

I'm not sure what type of testing this project usually required, I've only performed manual tests with a modified version of the component including this one line change and it seems to fix the problem. 