### PR TITLE
Fix state of the covers that don't have positioning feature

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -108,7 +108,7 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
     def is_closed(self):
         """Return if the cover is closed or not."""
         if self._config[CONF_POSITIONING_MODE] == COVER_MODE_NONE:
-            return False
+            return None
 
         if self._current_cover_position == 0:
             return True


### PR DESCRIPTION
Partially reverts https://github.com/rospogrigio/localtuya/commit/c15fcaa9b83cf63bdea99da68bac3fddbdd2fc93

That commit causes covers without positioning feature to appear as "Open" always and open feature will always be disabled