### PR TITLE
Add HVAC mode for the Qlima series of AC units

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -15,6 +15,9 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_IDLE,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
+    HVAC_MODE_COOL,
+    HVAC_MODE_DRY,
+    HVAC_MODE_FAN_ONLY,
     HVAC_MODE_OFF,
     PRESET_AWAY,
     PRESET_ECO,
@@ -95,6 +98,13 @@ HVAC_ACTION_SETS = {
         CURRENT_HVAC_HEAT: "Heat",
         CURRENT_HVAC_IDLE: "Warming",
     },
+    "auto/cold/wet/hot/wind": {
+        HVAC_MODE_AUTO: "auto",
+        HVAC_MODE_COOL: "cold",
+        HVAC_MODE_DRY: "wet",
+        HVAC_MODE_HEAT: "hot",
+        HVAC_MODE_FAN_ONLY: "wind",
+    }
 }
 PRESET_SETS = {
     "Manual/Holiday/Program": {


### PR DESCRIPTION
This change allows the LocalTuya integration to actually control all the modes of the AC units.
Tested on my own setup with a Qlima WMS S + SC52 (AB;AF) 

Inspired by this issue: https://github.com/rospogrigio/localtuya/issues/1186