### PR TITLE
feat: cover position scale

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -69,6 +69,7 @@ CONF_POSITIONING_MODE = "positioning_mode"
 CONF_CURRENT_POSITION_DP = "current_position_dp"
 CONF_SET_POSITION_DP = "set_position_dp"
 CONF_POSITION_INVERTED = "position_inverted"
+CONF_POSITION_SCALE = "position_scale"
 CONF_SPAN_TIME = "span_time"
 
 # fan

--- a/custom_components/localtuya/strings.json
+++ b/custom_components/localtuya/strings.json
@@ -61,6 +61,7 @@
                     "positioning_mode": "Positioning mode",
                     "current_position_dp": "Current Position (for *position* mode only)",
                     "set_position_dp": "Set Position (for *position* mode only)",
+                    "position_scale": "Scaling Factor (for *position* mode only)",
                     "position_inverted": "Invert 0-100 position (for *position* mode only)",
                     "span_time": "Full opening time, in secs. (for *timed* mode only)",
                     "unit_of_measurement": "Unit of Measurement",

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -131,6 +131,7 @@
                     "positioning_mode": "Positioning mode",
                     "current_position_dp": "Current Position (for *position* mode only)",
                     "set_position_dp": "Set Position (for *position* mode only)",
+                    "position_scale": "Scaling Factor (for *position* mode only)",
                     "position_inverted": "Invert 0-100 position (for *position* mode only)",
                     "span_time": "Full opening time, in secs. (for *timed* mode only)",
                     "unit_of_measurement": "Unit of Measurement",

--- a/custom_components/localtuya/translations/it.json
+++ b/custom_components/localtuya/translations/it.json
@@ -122,6 +122,7 @@
                     "positioning_mode": "Modalità di posizionamento",
                     "current_position_dp": "Posizione attuale (solo per la modalità *posizione*)",
                     "set_position_dp": "Imposta posizione (solo per modalità *posizione*)",
+                    "position_scale": "Fattore di scala (solo per modalità *posizione*)",
                     "position_inverted": "Inverti posizione 0-100 (solo per modalità *posizione*)",
                     "span_time": "Tempo di apertura totale, in sec. (solo per modalità *a tempo*)",
                     "unit_of_measurement": "Unità di misura",

--- a/custom_components/localtuya/translations/pt-BR.json
+++ b/custom_components/localtuya/translations/pt-BR.json
@@ -122,6 +122,7 @@
                     "positioning_mode": "Modo de posicionamento",
                     "current_position_dp": "Posição atual (somente para o modo *posição*)",
                     "set_position_dp": "Definir posição (somente para o modo *posição*)",
+                    "position_scale": "Fator de escala (somente para o modo *posição*)",
                     "position_inverted": "Inverter 0-100 posição (somente para o modo *posição*)",
                     "span_time": "Tempo de abertura completo, em segundos. (somente para o modo *temporizado*)",
                     "unit_of_measurement": "Unidade de medida",


### PR DESCRIPTION
Adds a scaling factor to the cover position. This allows for covers with a range that is not 0-100 to be used.

Reason: I have a cover with a range from 0 to 1000.