### PR TITLE
Calibration Feature

### DIFF
--- a/custom_components/localtuya/sensor.py
+++ b/custom_components/localtuya/sensor.py
@@ -16,13 +16,14 @@ from .const import CONF_SCALING
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PRECISION = 2
-
+CONF_CALIBRATION = "calibration"
 
 def flow_schema(dps):
     """Return schema used in config flow."""
     return {
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): str,
         vol.Optional(CONF_DEVICE_CLASS): vol.In(DEVICE_CLASSES),
+        vol.Optional(CONF_CALIBRATION): vol.Coerce(float),
         vol.Optional(CONF_SCALING): vol.All(
             vol.Coerce(float), vol.Range(min=-1000000.0, max=1000000.0)
         ),
@@ -62,8 +63,11 @@ class LocaltuyaSensor(LocalTuyaEntity):
         """Device status was updated."""
         state = self.dps(self._dp_id)
         scale_factor = self._config.get(CONF_SCALING)
+        calibration_factor = self._config.get(CONF_CALIBRATION, 0)
         if scale_factor is not None and isinstance(state, (int, float)):
-            state = round(state * scale_factor, DEFAULT_PRECISION)
+            state = round(state * scale_factor + calibration_factor, DEFAULT_PRECISION)
+        else:
+            state = round(state + calibration_factor, DEFAULT_PRECISION)
         self._state = state
 
     # No need to restore state for a sensor

--- a/custom_components/localtuya/strings.json
+++ b/custom_components/localtuya/strings.json
@@ -66,6 +66,7 @@
                     "unit_of_measurement": "Unit of Measurement",
                     "device_class": "Device Class",
                     "scaling": "Scaling Factor",
+                    "calibration": "Calibration Value",
                     "state_on": "On Value",
                     "state_off": "Off Value",
                     "powergo_dp": "Power DP (Usually 25 or 2)",

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -135,6 +135,7 @@
                     "span_time": "Full opening time, in secs. (for *timed* mode only)",
                     "unit_of_measurement": "Unit of Measurement",
                     "device_class": "Device Class",
+                    "calibration": "Calibration Value",
                     "scaling": "Scaling Factor",
                     "state_on": "On Value",
                     "state_off": "Off Value",

--- a/custom_components/localtuya/translations/it.json
+++ b/custom_components/localtuya/translations/it.json
@@ -127,6 +127,7 @@
                     "unit_of_measurement": "Unità di misura",
                     "device_class": "Classe del dispositivo",
                     "scaling": "Fattore di scala",
+                    "calibration": "Valore di calibrazione",
                     "state_on": "Valore di ON",
                     "state_off": "Valore di OFF",
                     "powergo_dp": "Potenza DP (di solito 25 o 2)",

--- a/custom_components/localtuya/translations/pt-BR.json
+++ b/custom_components/localtuya/translations/pt-BR.json
@@ -127,6 +127,7 @@
                     "unit_of_measurement": "Unidade de medida",
                     "device_class": "Classe do dispositivo",
                     "scaling": "Fator de escala",
+                    "calibration": "Valor de calibração",
                     "state_on": "Valor ligado",
                     "state_off": "Valor desligado",
                     "powergo_dp": "Potência DP (Geralmente 25 ou 2)",


### PR DESCRIPTION
We can calibrate sensors. For example: You have 2 temperature sensor devices but they  return different temperature values in the same room. You can calibrate one of them and make them equal.

![2025-01-15 20_18_31-Settings – Home Assistant](https://github.com/user-attachments/assets/860867b0-9519-4f8f-afa3-f7e71a07e422)
