### PR TITLE
feat: Add support for Auto/Heating/Cooling/Fan/Dehum hvac mode names

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -94,6 +94,13 @@ HVAC_MODE_SETS = {
         HVACMode.COOL: "cold",
         HVACMode.AUTO: "auto",
     },
+    "Auto/Heating/Cooling/Fan/Dehum": {
+        HVACMode.HEAT: "heating",
+        HVACMode.FAN_ONLY: "fan",
+        HVACMode.DRY: "dehum",
+        HVACMode.COOL: "cooling",
+        HVACMode.AUTO: "auto",
+    },
     "Cold/Dehumidify/Hot": {
         HVACMode.HEAT: "hot",
         HVACMode.DRY: "dehumidify",


### PR DESCRIPTION
This commit adds support for Tadiran AC Wi-Fi controllers that use the Auto/Heating/Cooling/Fan/Dehum HVAC mode naming scheme

