### PR TITLE
Added missing int castings for config values (fix for 2025.05)

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -171,10 +171,10 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         )
         self._upper_color_temp = self._upper_brightness
         self._max_mired = color_util.color_temperature_kelvin_to_mired(
-            self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN)
+            int(self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN))
         )
         self._min_mired = color_util.color_temperature_kelvin_to_mired(
-            self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN)
+            int(self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN))
         )
         self._color_temp_reverse = self._config.get(
             CONF_COLOR_TEMP_REVERSE, DEFAULT_COLOR_TEMP_REVERSE
@@ -186,7 +186,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         self._scenes = {}
 
         if self.has_config(CONF_SCENE):
-            if self._config.get(CONF_SCENE) < 20:
+            if int(self._config.get(CONF_SCENE)) < 20:
                 self._scenes = SCENE_LIST_RGBW_255
             elif self._config.get(CONF_BRIGHTNESS) is None:
                 self._scenes = SCENE_LIST_RGB_1000


### PR DESCRIPTION
My homeassistant instance was throwing error logs about multiple missing castings (and thus mixed str/int operations) after update to HA 2025.05 and latest localtuya addon version.

Not sure if it is specific for my set of devices, but these values in fact **should alway be integer** type anyway so it can not bring any harm. My integration was failing to start without these.