### PR TITLE
feat: add support for SG data center

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -75,7 +75,7 @@ CONFIGURE_SCHEMA = vol.Schema(
 
 CLOUD_SETUP_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_REGION, default="eu"): vol.In(["eu", "us", "cn", "in"]),
+        vol.Required(CONF_REGION, default="eu"): vol.In(["eu", "us", "cn", "in", "sg"]),
         vol.Optional(CONF_CLIENT_ID): cv.string,
         vol.Optional(CONF_CLIENT_SECRET): cv.string,
         vol.Optional(CONF_USER_ID): cv.string,


### PR DESCRIPTION
This PR adds support for the SG data center during the Cloud API account configuration flow so that Tuya accounts created in the SG data center can complete the setup. Without this change, users who created their Tuya accounts using the SG data center location cannot complete the setup.

![CleanShot 2025-06-22 at 21 57 50@2x](https://github.com/user-attachments/assets/337f7bb1-6fd8-4038-8165-4f5992b3dbc4)
