### PR TITLE
Update climate.py add lower case manual program

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -80,6 +80,10 @@ HVAC_MODE_SETS = {
         HVACMode.HEAT: "Manual",
         HVACMode.AUTO: "Program",
     },
+    "manual/program": {
+        HVACMode.HEAT: "manual",
+        HVACMode.AUTO: "program",
+    },
     "m/p": {
         HVACMode.HEAT: "m",
         HVACMode.AUTO: "p",


### PR DESCRIPTION
## Isue
❓  `Manual `and `Program ` (existing maped values) with 1st word uppercase doesnt match the TUYA api at `Get the status of a single device` API using TUYA developer api explorer

## Fix
💡  Added `manual `and `program`, lowercase to match the expected results

## Context/Usage
for AC603H and AC605H WIFI THERMOSTATS

## Img  - raw response from TUYA API
![image](https://github.com/user-attachments/assets/e826397d-bfde-402a-be32-3e0547dcd723)
![image](https://github.com/user-attachments/assets/d13654d1-e588-4234-a5e5-d6ebb8f43527)
