### PR TITLE
Update climate.py

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -94,6 +94,12 @@ HVAC_MODE_SETS = {
         HVACMode.COOL: "cold",
         HVACMode.AUTO: "auto",
     },
+    "Cool/Heat/Dry/Fan": {
+        HVACMode.COOL: "cool", 
+        HVACMode.HEAT: "heat",
+        HVACMode.DRY: "dry",
+        HVACMode.FAN_ONLY: "fan_only",
+    },
     "Cold/Dehumidify/Hot": {
         HVACMode.HEAT: "hot",
         HVACMode.DRY: "dehumidify",
@@ -133,6 +139,11 @@ HVAC_FAN_MODE_SETS = {
         FAN_MEDIUM: "middle",
         FAN_HIGH: "high",
         FAN_TOP: "strong",
+    },
+    "1/2/3": {
+        FAN_LOW: "1",
+        FAN_MEDIUM: "2", 
+        FAN_HIGH: "3",
     }
 }
 HVAC_SWING_MODE_SETS = {


### PR DESCRIPTION
# Add HVAC mode and fan mode sets for Qlima WDH 229 Monoblock Air Conditioner

## Description
This PR adds support for the **Qlima WDH 229** monoblock air conditioner by adding new HVAC mode and fan mode sets to the Local Tuya climate platform.

## Device Information
- **Brand**: Qlima
- **Model**: WDH 229 (Monoblock Air Conditioner with heating and cooling)
- **Product Page**: https://www.qlima.com/monoblock-airco-cooling-and-heating-wdh-229-white.html
- **Tuya Protocol**: 3.4
- **HVAC Mode DP**: 4
- **Fan Mode DP**: 5

## Tested Modes

### HVAC Modes (DP 4)
The device supports these text-based HVAC modes:
- `cool` - Cooling mode  
- `heat` - Heating mode
- `dry` - Dehumidification mode
- `fan_only` - Fan only mode

### Fan Modes (DP 5) 
The device supports these numeric fan speeds:
- `1` - Low speed
- `2` - Medium speed  
- `3` - High speed

## Changes Made

### HVAC_MODE_SETS
Added new mode set `"Cool/Heat/Dry/Fan"`

```python
"Cool/Heat/Dry/Fan": {
    HVACMode.COOL: "cool", 
    HVACMode.HEAT: "heat",
    HVACMode.DRY: "dry",
    HVACMode.FAN_ONLY: "fan_only",
},
```

### HVAC_FAN_MODE_SETS  
Added new fan mode set `"1/2/3"`

```python
"1/2/3": {
    FAN_LOW: "1",
    FAN_MEDIUM: "2", 
    FAN_HIGH: "3",
}
```

## Testing
- [x] Device discovered successfully via Local Tuya
- [x] All HVAC modes work correctly (cool/heat/dry/fan_only)
- [x] All fan speeds work correctly (1/2/3)
- [x] Temperature control works (16-30°C range)
- [x] Status feedback works properly
- [x] Two-way synchronization between HA and device works

## Device Configuration
After this PR, users can configure the Qlima WDH 229 in Local Tuya using:
- **HVAC Mode DP**: 4
- **HVAC Mode Set**: `Cool/Heat/Dry/Fan`
- **Fan Mode DP**: 5  
- **Fan Mode Set**: `1/2/3` (or `Auto/1/2/3` if auto mode is desired)
- **Target Temperature DP**: 2
- **Current Temperature DP**: 3

## Compatibility
These new mode sets should also work for other similar Tuya-based air conditioners that use:
- Text-based HVAC modes: cool, heat, dry, fan_only
- Numeric fan speeds: 1, 2, 3