### PR TITLE
Fix frequent error "Exception in callback _SelectorDatagramTransport.…

### DIFF
--- a/custom_components/localtuya/discovery.py
+++ b/custom_components/localtuya/discovery.py
@@ -60,13 +60,35 @@ class TuyaDiscovery(asyncio.DatagramProtocol):
 
     def datagram_received(self, data, addr):
         """Handle received broadcast message."""
-        data = data[20:-8]
-        try:
-            data = decrypt_udp(data)
-        except Exception:  # pylint: disable=broad-except
-            data = data.decode()
+        raw_data = data[20:-8]
 
-        decoded = json.loads(data)
+        # Attempt to decrypt the incoming UDP packet using Tuya's AES encryption.
+        # If it fails (e.g., due to incorrect length), fallback to decoding as plain UTF-8.
+        try:
+            decrypted = decrypt_udp(raw_data)
+        except Exception as e:
+            _LOGGER.debug(f"decrypt_udp() failed: {e}")
+            try:
+                decrypted = raw_data.decode()
+            except Exception as decode_error:
+                _LOGGER.debug(f"Failed to decode raw UDP data: {decode_error}")
+                return
+
+        # Ensure that the decrypted payload looks like a proper JSON object.
+        # Valid Tuya JSON messages should start with '{' and end with '}'.
+        if not (decrypted.strip().startswith("{") and decrypted.strip().endswith("}")):
+            _LOGGER.warning("Discarded malformed UDP packet (not valid JSON): %r", decrypted)
+            return
+
+        # Attempt to parse the decrypted string into a JSON object.
+        # If parsing fails, log the malformed content for debugging.
+        try:
+            decoded = json.loads(decrypted)
+        except Exception as json_error:
+            _LOGGER.warning("Failed to parse JSON from UDP packet: %r", decrypted)
+            _LOGGER.debug("JSON parsing error: %s", json_error)
+            return
+
         self.device_found(decoded)
 
     def device_found(self, device):


### PR DESCRIPTION
### Problem
The localtuya custom component’s UDP discovery handler was logging a high volume of errors:

```
ERROR (MainThread) [homeassistant] Error doing job: Exception in callback _SelectorDatagramTransport._read_ready() (None)
Traceback (most recent call last):
  File "/config/custom_components/localtuya/discovery.py", line 65, in datagram_received
    data = decrypt_udp(data)
  File "/config/custom_components/localtuya/discovery.py", line 30, in decrypt_udp
    return _unpad(decryptor.update(message) + decryptor.finalize()).decode()
                                              ~~~~~~~~~~~~~~~~~~^^
ValueError: The length of the provided data is not a multiple of the block length.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/asyncio/selector_events.py", line 1243, in _read_ready
    self._protocol.datagram_received(data, addr)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/config/custom_components/localtuya/discovery.py", line 67, in datagram_received
    data = data.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8f in position 0: invalid start byte
```

Although these errors did not affect functionality, they flooded the logs with hundreds of thousands of entries per day, making debugging difficult and increasing log storage.

### Solution
This PR improves the datagram_received method to:

- Gracefully handle decryption failures by attempting to decode raw data

- Handle decoding errors without exceptions

- Validate that decrypted data is JSON-formatted before parsing

- Log warnings for malformed or unexpected packets instead of raising exceptions

These changes significantly reduce noisy error logs and improve the stability and clarity of localtuya's UDP discovery.