### PR TITLE
Addressing thread safety for dispatch in 2025.8.2

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -348,13 +348,21 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
     def _dispatch_status(self):
         signal = f"localtuya_{self._dev_config_entry[CONF_DEVICE_ID]}"
-        async_dispatcher_send(self._hass, signal, self._status)
+#        async_dispatcher_send(self._hass, signal, self._status)
+        # Ensure dispatcher runs on HA's event loop (thread-safe)
+        self._hass.loop.call_soon_threadsafe(
+            async_dispatcher_send, self._hass, signal, self._status
+        )
 
     @callback
     def disconnected(self):
         """Device disconnected."""
         signal = f"localtuya_{self._dev_config_entry[CONF_DEVICE_ID]}"
-        async_dispatcher_send(self._hass, signal, None)
+#        async_dispatcher_send(self._hass, signal, None)
+        # Ensure dispatcher runs on HA's event loop (thread-safe)
+        self._hass.loop.call_soon_threadsafe(
+             async_dispatcher_send, self._hass, signal, None
+        )
         if self._unsub_interval is not None:
             self._unsub_interval()
             self._unsub_interval = None


### PR DESCRIPTION
I had some problems with devices that had mulitple entities
of the same kind, eg switches, outlets etc in
HASS 2025.8.2 as per #2058 
This has fixed it, but I have not tested for backward compatibility