### PR TITLE
[Draft] custom temp conversion for prime AC units

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -378,7 +378,10 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         if ATTR_TEMPERATURE in kwargs and self.has_config(CONF_TARGET_TEMPERATURE_DP):
-            temperature = round(kwargs[ATTR_TEMPERATURE] / self._target_precision)
+            # Convert Celsius to Fahrenheit and multiply by 10 for device
+            temp_c = kwargs[ATTR_TEMPERATURE]
+            temp_f = (temp_c * 9 / 5) + 32
+            temperature = round(temp_f * 10)
             await self._device.set_dp(
                 temperature, self._config[CONF_TARGET_TEMPERATURE_DP]
             )
@@ -456,9 +459,9 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
         self._state = self.dps(self._dp_id)
 
         if self.has_config(CONF_TARGET_TEMPERATURE_DP):
-            self._target_temperature = (
-                self.dps_conf(CONF_TARGET_TEMPERATURE_DP) * self._target_precision
-            )
+            # Device reports target temp in Fahrenheit * 10, convert to Celsius
+            temp_f = self.dps_conf(CONF_TARGET_TEMPERATURE_DP) / 10
+            self._target_temperature = (temp_f - 32) * 5 / 9
 
         if self.has_config(CONF_CURRENT_TEMPERATURE_DP):
             self._current_temperature = (


### PR DESCRIPTION
This not intended to be merged, just raising as a reference point

# Description

I have an AC that came with a Tuya controller that has a quirk where the device reports the current temperature in C but reports the target temp in F. This leads to a situation where the target temp displayed in the HA UI is drastically wrong (because it is being double converted to F)

<img width="613" height="627" alt="IMG_6558" src="https://github.com/user-attachments/assets/0b4f656b-88df-4c60-ace8-12219e644bcd" />

Current temp 75F - correct
Target temp of 154F - incorrect
154F = 68C 
68F is the correct value

The solution in this PR is only for me to be able to use it, but can be used as a reference point for solving the issue more broadly. I think perhaps allowing an input for what temp scale to use for each could work the easiest. 