### PR TITLE
add support for eurom aluterm heaters

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -103,6 +103,10 @@ HVAC_MODE_SETS = {
         HVACMode.HEAT: "1",
         HVACMode.AUTO: "0",
     },
+    "manual (m) / automatic (p)": {
+        HVACMode.HEAT: "manual",
+        HVACMode.AUTO: "auto",
+    },
 }
 HVAC_ACTION_SETS = {
     "True/False": {
@@ -151,6 +155,12 @@ PRESET_SETS = {
         PRESET_AWAY: "holiday",
         PRESET_HOME: "smart",
         PRESET_NONE: "hold",
+    },
+    "low/mid/high/off": {
+        "off": "off",
+        "low": "low",
+        "mid": "mid",
+        "high": "high",
     },
 }
 


### PR DESCRIPTION
The research and `climate.py` snippets reported in this [HA thread](https://community.home-assistant.io/t/eurom-alutherm-heater-in-ha/357419/31) enable localtuya to support EUROM Aluterm series of heaters.

This PR introduces the changes reported to be working in the thread.

The changes have been tested and confirmed to be working locally.