### PR TITLE
force ipv4 for tuya cloud api requests

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -311,6 +311,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         if device.connected:
             await device.close()
 
+    await hass.data[DOMAIN][DATA_CLOUD].async_close()
+
     if unload_ok:
         hass.data[DOMAIN][TUYA_DEVICES] = {}
 

--- a/custom_components/localtuya/cloud_api.py
+++ b/custom_components/localtuya/cloud_api.py
@@ -55,6 +55,15 @@ class TuyaCloudApi:
         self._session = requests.Session()
         self._session.mount("https://", IPv4Adapter())
 
+    def close(self):
+        """Close underlying HTTP session."""
+        if self._session is not None:
+            self._session.close()
+
+    async def async_close(self):
+        """Asynchronously close underlying HTTP session."""
+        await self._hass.async_add_executor_job(self.close)
+
     def generate_payload(self, method, timestamp, url, headers, body=None):
         """Generate signed payload for requests."""
         payload = self._client_id + self._access_token + timestamp

--- a/custom_components/localtuya/cloud_api.py
+++ b/custom_components/localtuya/cloud_api.py
@@ -4,11 +4,24 @@ import hashlib
 import hmac
 import json
 import logging
+import socket
 import time
 
 import requests
+import urllib3
+from requests.adapters import HTTPAdapter
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class IPv4Adapter(HTTPAdapter):
+    def send(self, *args, **kwargs):
+        old = urllib3.util.connection.allowed_gai_family
+        urllib3.util.connection.allowed_gai_family = lambda: socket.AF_INET
+        try:
+            return super().send(*args, **kwargs)
+        finally:
+            urllib3.util.connection.allowed_gai_family = old
 
 
 # Signature algorithm.
@@ -38,6 +51,9 @@ class TuyaCloudApi:
         self._user_id = user_id
         self._access_token = ""
         self.device_list = {}
+
+        self._session = requests.Session()
+        self._session.mount("https://", IPv4Adapter())
 
     def generate_payload(self, method, timestamp, url, headers, body=None):
         """Generate signed payload for requests."""
@@ -77,11 +93,11 @@ class TuyaCloudApi:
 
         if method == "GET":
             func = functools.partial(
-                requests.get, full_url, headers=dict(default_par, **headers)
+                self._session.get, full_url, headers=dict(default_par, **headers)
             )
         elif method == "POST":
             func = functools.partial(
-                requests.post,
+                self._session.post,
                 full_url,
                 headers=dict(default_par, **headers),
                 data=json.dumps(body),
@@ -89,7 +105,7 @@ class TuyaCloudApi:
             # _LOGGER.debug("BODY: [%s]", body)
         elif method == "PUT":
             func = functools.partial(
-                requests.put,
+                self._session.put,
                 full_url,
                 headers=dict(default_par, **headers),
                 data=json.dumps(body),

--- a/custom_components/localtuya/cloud_api.py
+++ b/custom_components/localtuya/cloud_api.py
@@ -5,23 +5,39 @@ import hmac
 import json
 import logging
 import socket
+import threading
 import time
 
 import requests
-import urllib3
+import urllib3.util.connection
 from requests.adapters import HTTPAdapter
 
 _LOGGER = logging.getLogger(__name__)
 
+# Thread-local flag so each executor thread can independently request IPv4-only
+# DNS resolution without mutating a process-global function per request.
+_thread_local = threading.local()
+_orig_allowed_gai_family = urllib3.util.connection.allowed_gai_family
+
+
+def _thread_local_allowed_gai_family():
+    """Return AF_INET for this thread when IPv4-only mode is active."""
+    if getattr(_thread_local, "force_ipv4", False):
+        return socket.AF_INET
+    return _orig_allowed_gai_family()
+
+
+# Single, one-time replacement — no per-request global mutation.
+urllib3.util.connection.allowed_gai_family = _thread_local_allowed_gai_family
+
 
 class IPv4Adapter(HTTPAdapter):
     def send(self, *args, **kwargs):
-        old = urllib3.util.connection.allowed_gai_family
-        urllib3.util.connection.allowed_gai_family = lambda: socket.AF_INET
+        _thread_local.force_ipv4 = True
         try:
             return super().send(*args, **kwargs)
         finally:
-            urllib3.util.connection.allowed_gai_family = old
+            _thread_local.force_ipv4 = False
 
 
 # Signature algorithm.

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -352,6 +352,7 @@ class LocaltuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self._create_entry(user_input)
 
             cloud_api, res = await attempt_cloud_connection(self.hass, user_input)
+            await cloud_api.async_close()
 
             if not res:
                 return await self._create_entry(user_input)
@@ -439,11 +440,12 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
                 )
 
             cloud_api, res = await attempt_cloud_connection(self.hass, user_input)
+            cloud_devs = cloud_api.device_list
+            await cloud_api.async_close()
 
             if not res:
                 new_data = self.config_entry.data.copy()
                 new_data.update(user_input)
-                cloud_devs = cloud_api.device_list
                 for dev_id, dev in new_data[CONF_DEVICES].items():
                     if CONF_MODEL not in dev and dev_id in cloud_devs:
                         model = cloud_devs[dev_id].get(CONF_PRODUCT_NAME)


### PR DESCRIPTION
## Problem
The Tuya Cloud API requests could use IPv6, which causes connection issues in some environments
https://github.com/rospogrigio/localtuya/issues/1974

## Solution
- Introduced a custom `IPv4Adapter` (extends `HTTPAdapter`) that temporarily overrides `urllib3.util.connection.allowed_gai_family` to `socket.AF_INET` during connection setup
- Replaced standalone `requests.get/post/put` calls with a persistent `requests.Session` mounted with the `IPv4Adapter` for `https://`