### PR TITLE
fix: Heat Pump LocalTuya - port fallback, diagnostics, log throttling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .tox
 tuyadebug/
 .pre-commit-config.yaml
+exclude/

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -150,6 +150,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         self._entities = []
         self._local_key = self._dev_config_entry[CONF_LOCAL_KEY]
         self._default_reset_dpids = None
+        self._last_disconnect_log = 0.0
         if CONF_RESET_DPIDS in self._dev_config_entry:
             reset_ids_str = self._dev_config_entry[CONF_RESET_DPIDS].split(",")
 
@@ -195,11 +196,17 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 float(self._dev_config_entry[CONF_PROTOCOL_VERSION]),
                 self._dev_config_entry.get(CONF_ENABLE_DEBUG, False),
                 self,
+                ports=pytuya.DEFAULT_PORTS,
             )
             self._interface.add_dps_to_request(self.dps_to_request)
         except Exception as ex:  # pylint: disable=broad-except
+            host = self._dev_config_entry[CONF_HOST]
+            ports_str = ",".join(str(p) for p in pytuya.DEFAULT_PORTS)
             self.warning(
-                f"Failed to connect to {self._dev_config_entry[CONF_HOST]}: %s", ex
+                "Failed to connect to %s (tried ports %s): %s",
+                host,
+                ports_str,
+                ex,
             )
             if self._interface is not None:
                 await self._interface.close()
@@ -217,12 +224,16 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                     self.status_updated(status)
 
                 except Exception as ex:
+                    self.warning(
+                        "Initial state retrieval failed: %s (%s)",
+                        type(ex).__name__,
+                        ex,
+                    )
                     if (self._default_reset_dpids is not None) and (
                         len(self._default_reset_dpids) > 0
                     ):
-                        self.debug(
-                            "Initial state update failed, trying reset command "
-                            + "for DP IDs: %s",
+                        self.info(
+                            "Trying reset command for DP IDs: %s",
                             self._default_reset_dpids,
                         )
                         await self._interface.reset(self._default_reset_dpids)
@@ -235,7 +246,11 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                         self._interface.start_heartbeat()
                         self.status_updated(status)
                     else:
-                        self.error("Initial state update failed, giving up: %r", ex)
+                        self.error(
+                            "Initial state update failed, giving up: %s (%s)",
+                            type(ex).__name__,
+                            ex,
+                        )
                         if self._interface is not None:
                             await self._interface.close()
                             self._interface = None
@@ -363,7 +378,11 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         if self._connect_task is not None:
             self._connect_task.cancel()
             self._connect_task = None
-        self.warning("Disconnected - waiting for discovery broadcast")
+        # Throttle log to avoid spam (max once per 60 seconds)
+        now = time.time()
+        if now - self._last_disconnect_log >= 60:
+            self._last_disconnect_log = now
+            self.warning("Disconnected - waiting for discovery broadcast")
 
 
 class LocalTuyaEntity(RestoreEntity, pytuya.ContextualLogger):

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -245,6 +245,7 @@ async def validate_input(hass: core.HomeAssistant, data):
             data[CONF_LOCAL_KEY],
             float(data[CONF_PROTOCOL_VERSION]),
             data[CONF_ENABLE_DEBUG],
+            ports=pytuya.DEFAULT_PORTS,
         )
         if CONF_RESET_DPIDS in data:
             reset_ids_str = data[CONF_RESET_DPIDS].split(",")
@@ -284,7 +285,7 @@ async def validate_input(hass: core.HomeAssistant, data):
                 if str(new_dps) not in detected_dps:
                     detected_dps[new_dps] = -1
 
-    except (ConnectionRefusedError, ConnectionResetError) as ex:
+    except (ConnectionRefusedError, ConnectionResetError, OSError) as ex:
         raise CannotConnect from ex
     except ValueError as ex:
         raise InvalidAuth from ex

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -163,6 +163,9 @@ NO_PROTOCOL_HEADER_CMDS = [
 
 HEARTBEAT_INTERVAL = 10
 
+# Default ports to try when connection fails (aligned with tinytuya)
+DEFAULT_PORTS = [6668, 6669, 8681]
+
 # DPS that are known to be safe to use with update_dps (0x12) command
 UPDATE_DPS_WHITELIST = [18, 19, 20]  # Socket (Wi-Fi)
 
@@ -723,7 +726,21 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 msg = await self.dispatcher.wait_for(seqno, payload.cmd)
                 # for 3.4 devices, we get the starting seqno with the SESS_KEY_NEG_RESP message
                 self.seqno = msg.seqno
-            except Exception:
+            except asyncio.TimeoutError:
+                _LOGGER.info(
+                    "[%s] Session key negotiation timeout (cmd %d, %s retries left)",
+                    self.id[:8] + "..." + self.id[-4:] if len(self.id) > 12 else self.id,
+                    payload.cmd,
+                    recv_retries - 1,
+                )
+                msg = None
+            except Exception as ex:
+                _LOGGER.info(
+                    "[%s] Session key negotiation error: %s (%s)",
+                    self.id[:8] + "..." + self.id[-4:] if len(self.id) > 12 else self.id,
+                    type(ex).__name__,
+                    ex,
+                )
                 msg = None
             if msg and len(msg.payload) != 0:
                 return msg
@@ -974,13 +991,18 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             MessagePayload(SESS_KEY_NEG_START, self.local_nonce), 2
         )
         if not rkey or not isinstance(rkey, TuyaMessage) or len(rkey.payload) < 48:
-            # error
-            self.debug("session key negotiation failed on step 1")
+            _LOGGER.info(
+                "[%s] Session key negotiation failed: no/invalid response (step 1)",
+                self.id[:8] + "..." + self.id[-4:] if len(self.id) > 12 else self.id,
+            )
             return False
 
         if rkey.cmd != SESS_KEY_NEG_RESP:
-            self.debug(
-                "session key negotiation step 2 returned wrong command: %d", rkey.cmd
+            _LOGGER.info(
+                "[%s] Session key negotiation failed: wrong cmd %d (expected %d)",
+                self.id[:8] + "..." + self.id[-4:] if len(self.id) > 12 else self.id,
+                rkey.cmd,
+                SESS_KEY_NEG_RESP,
             )
             return False
 
@@ -990,10 +1012,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             cipher = AESCipher(self.real_local_key)
             payload = cipher.decrypt(payload, False, decode_text=False)
         except Exception as ex:
-            self.debug(
-                "session key step 2 decrypt failed, payload=%r with len:%d (%s)",
-                payload,
-                len(payload),
+            _LOGGER.info(
+                "[%s] Session key negotiation failed: decrypt error (%s)",
+                self.id[:8] + "..." + self.id[-4:] if len(self.id) > 12 else self.id,
                 ex,
             )
             return False
@@ -1001,7 +1022,11 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         self.debug("decrypted session key negotiation step 2: payload=%r", payload)
 
         if len(payload) < 48:
-            self.debug("session key negotiation step 2 failed, too short response")
+            _LOGGER.info(
+                "[%s] Session key negotiation failed: response too short (%d bytes)",
+                self.id[:8] + "..." + self.id[-4:] if len(self.id) > 12 else self.id,
+                len(payload),
+            )
             return False
 
         self.remote_nonce = payload[:16]
@@ -1174,23 +1199,61 @@ async def connect(
     enable_debug,
     listener=None,
     port=6668,
+    ports=None,
     timeout=5,
 ):
-    """Connect to a device."""
-    loop = asyncio.get_running_loop()
-    on_connected = loop.create_future()
-    _, protocol = await loop.create_connection(
-        lambda: TuyaProtocol(
-            device_id,
-            local_key,
-            protocol_version,
-            enable_debug,
-            on_connected,
-            listener or EmptyListener(),
-        ),
-        address,
-        port,
-    )
+    """Connect to a device.
 
-    await asyncio.wait_for(on_connected, timeout=timeout)
-    return protocol
+    Args:
+        address: Device IP address.
+        device_id: Tuya device ID.
+        local_key: Tuya local key.
+        protocol_version: Protocol version (3.1, 3.2, 3.3, 3.4).
+        enable_debug: Enable debug logging.
+        listener: Optional TuyaListener for status updates.
+        port: Single port to try (used when ports is None).
+        ports: List of ports to try in order. If provided, overrides port.
+        timeout: Connection timeout per port.
+
+    Returns:
+        TuyaProtocol instance on success.
+    """
+    loop = asyncio.get_running_loop()
+    ports_to_try = ports if ports is not None else [port]
+    last_error = None
+    multi_port = len(ports_to_try) > 1
+
+    for p in ports_to_try:
+        if multi_port:
+            _LOGGER.info("Trying %s:%d", address, p)
+        on_connected = loop.create_future()
+        try:
+            _, protocol = await loop.create_connection(
+                lambda oc=on_connected: TuyaProtocol(
+                    device_id,
+                    local_key,
+                    protocol_version,
+                    enable_debug,
+                    oc,
+                    listener or EmptyListener(),
+                ),
+                address,
+                p,
+            )
+            await asyncio.wait_for(on_connected, timeout=timeout)
+            if multi_port:
+                _LOGGER.info("Connected to %s on port %d", address, p)
+            return protocol
+        except (ConnectionRefusedError, ConnectionResetError, OSError) as ex:
+            last_error = ex
+            errno_str = f" errno={getattr(ex, 'errno', '?')}" if hasattr(ex, "errno") else ""
+            _LOGGER.info("Port %d failed%s: %s", p, errno_str, ex)
+            continue
+        except asyncio.TimeoutError as ex:
+            last_error = ex
+            _LOGGER.info("Port %d timeout after %ds", p, timeout)
+            continue
+
+    if last_error is not None:
+        raise last_error
+    raise ConnectionError("Failed to connect to device")

--- a/info.md
+++ b/info.md
@@ -157,6 +157,12 @@ You can obtain Energy monitoring (voltage, current) in two different ways:
 
 # Debugging
 
+When connection issues occur, the integration logs diagnostic info at INFO level:
+- Port attempts: `Trying 192.168.68.52:6668`, `Port 6668 failed errno=104: ...`
+- Connection failure: `Failed to connect to X (tried ports 6668,6669,8681): ...`
+- Session key (3.4): timeout or decrypt errors
+- Initial state: `Initial state retrieval failed: TimeoutError (...)`
+
 Whenever you write a bug report, it helps tremendously if you include debug logs directly (otherwise we will just ask for them and it will take longer). So please enable debug logs like this and include them in your issue:
 
 ```yaml

--- a/tools/test_heat_pump_status.py
+++ b/tools/test_heat_pump_status.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Standalone diagnostic script for LocalTuya Heat Pump connection issues.
+
+Usage:
+    python tools/test_heat_pump_status.py --host 192.168.68.52 \\
+        --device-id bff61d6d17fb8a70daxn4y --local-key "YOUR_KEY"
+    python tools/test_heat_pump_status.py --host 192.168.68.52 \\
+        --device-id xxx --local-key xxx --ports 6668,6669,8681 --versions 3.3,3.4
+
+Run from project root. Requires: pip install cryptography
+"""
+import argparse
+import asyncio
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+# Load pytuya directly without homeassistant (avoids homeassistant dependency)
+try:
+    _pytuya_path = (
+        Path(__file__).resolve().parent.parent
+        / "custom_components"
+        / "localtuya"
+        / "pytuya"
+        / "__init__.py"
+    )
+    _spec = importlib.util.spec_from_file_location("pytuya", _pytuya_path)
+    pytuya = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(pytuya)
+except ModuleNotFoundError as e:
+    print(f"Missing dependency: {e}. Run: pip install cryptography")
+    sys.exit(1)
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+_LOGGER = logging.getLogger("test_heat_pump")
+
+
+async def test_connection(host, device_id, local_key, port, version, timeout=5):
+    """Try connecting and fetching status on a single port/version."""
+    _LOGGER.info(
+        "Trying host=%s port=%s version=%s device_id=%s",
+        host,
+        port,
+        version,
+        device_id[:8] + "..." + device_id[-4:] if len(device_id) > 12 else device_id,
+    )
+    try:
+        protocol = await pytuya.connect(
+            host,
+            device_id,
+            local_key,
+            float(version),
+            enable_debug=True,
+            port=port,
+            timeout=timeout,
+        )
+        _LOGGER.info("Connected on port %s, fetching status...", port)
+        status = await protocol.status()
+        await protocol.close()
+        _LOGGER.info("Status: %s", status)
+        return status
+    except (ConnectionRefusedError, ConnectionResetError, OSError) as ex:
+        _LOGGER.warning("Connection failed on port %s: %s", port, ex)
+        raise
+    except asyncio.TimeoutError as ex:
+        _LOGGER.warning("Timeout on port %s: %s", port, ex)
+        raise
+    except Exception as ex:
+        _LOGGER.exception("Unexpected error: %s", ex)
+        raise
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Test Tuya device connection")
+    parser.add_argument("--host", required=True, help="Device IP address")
+    parser.add_argument("--device-id", required=True, help="Tuya device ID")
+    parser.add_argument("--local-key", required=True, help="Tuya local key")
+    parser.add_argument(
+        "--ports",
+        default="6668,6669,8681",
+        help="Comma-separated ports to try (default: 6668,6669,8681)",
+    )
+    parser.add_argument(
+        "--versions",
+        default="3.4",
+        help="Comma-separated protocol versions (default: 3.4)",
+    )
+    parser.add_argument("--timeout", type=int, default=5, help="Connection timeout")
+    args = parser.parse_args()
+
+    ports = [int(p.strip()) for p in args.ports.split(",")]
+    versions = [v.strip() for v in args.versions.split(",")]
+
+    last_error = None
+    for version in versions:
+        for port in ports:
+            try:
+                status = await test_connection(
+                    args.host,
+                    args.device_id,
+                    args.local_key,
+                    port,
+                    version,
+                    args.timeout,
+                )
+                _LOGGER.info(
+                    "SUCCESS: Connected on port %s with version %s. DPS: %s",
+                    port,
+                    version,
+                    status,
+                )
+                return 0
+            except (ConnectionRefusedError, ConnectionResetError, OSError) as ex:
+                last_error = ex
+                continue
+            except asyncio.TimeoutError as ex:
+                last_error = ex
+                continue
+
+    _LOGGER.error("All attempts failed. Last error: %s", last_error)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
- Add port fallback (6668, 6669, 8681) for devices that reject default port
- Add tools/test_heat_pump_status.py for standalone connection testing
- Add diagnostic logging: port attempts, session key negotiation, initial state
- Throttle 'Disconnected' log to once per 60 seconds
- Add exclude/ to .gitignore

Made-with: Cursor