### PR TITLE
fix: Heat pump connection reset after firmware update (fixes #2189)

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -131,6 +131,26 @@ def async_config_entry_by_device_id(hass, device_id):
     return None
 
 
+class _InitialConnectListener(pytuya.TuyaListener):
+    """Listener that suppresses status_updated during initial handshake.
+
+    Some devices (e.g. heat pumps) reset the connection when status_updated
+    triggers entity dispatch during the first exchange. This wrapper defers
+    status_updated until after the initial status is retrieved.
+    """
+
+    def __init__(self, device):
+        self._device = device
+        self._initial_done = False
+
+    def status_updated(self, status):
+        if self._initial_done:
+            self._device.status_updated(status)
+
+    def disconnected(self):
+        self._device.disconnected()
+
+
 class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
     """Cache wrapper for pytuya.TuyaInterface."""
 
@@ -179,7 +199,6 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
     def async_connect(self):
         """Connect to device if not already connected."""
-        # self.info("async_connect: %d %r %r", self._is_closing, self._connect_task, self._interface)
         if not self._is_closing and self._connect_task is None and not self._interface:
             self._connect_task = asyncio.create_task(self._make_connection())
 
@@ -188,18 +207,25 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         self.info("Trying to connect to %s...", self._dev_config_entry[CONF_HOST])
 
         try:
+            initial_listener = _InitialConnectListener(self)
             self._interface = await pytuya.connect(
                 self._dev_config_entry[CONF_HOST],
                 self._dev_config_entry[CONF_DEVICE_ID],
                 self._local_key,
                 float(self._dev_config_entry[CONF_PROTOCOL_VERSION]),
                 self._dev_config_entry.get(CONF_ENABLE_DEBUG, False),
-                self,
+                initial_listener,
+                ports=pytuya.DEFAULT_PORTS,
             )
-            self._interface.add_dps_to_request(self.dps_to_request)
+            # Don't add dps_to_request before first status - some devices (e.g. heat pumps)
+            # reject the connection when specific DPs are requested in the initial query.
+            # Delay: some devices need time after TCP connect before first Tuya packet.
+            await asyncio.sleep(1.5)
         except Exception as ex:  # pylint: disable=broad-except
             self.warning(
-                f"Failed to connect to {self._dev_config_entry[CONF_HOST]}: %s", ex
+                "Failed to connect to %s: %s",
+                self._dev_config_entry[CONF_HOST],
+                ex,
             )
             if self._interface is not None:
                 await self._interface.close()
@@ -213,6 +239,8 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                     if status is None:
                         raise Exception("Failed to retrieve status")
 
+                    initial_listener._initial_done = True
+                    self._interface.add_dps_to_request(self.dps_to_request)
                     self._interface.start_heartbeat()
                     self.status_updated(status)
 
@@ -232,6 +260,8 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                         if status is None or not status:
                             raise Exception("Failed to retrieve status") from ex
 
+                        initial_listener._initial_done = True
+                        self._interface.add_dps_to_request(self.dps_to_request)
                         self._interface.start_heartbeat()
                         self.status_updated(status)
                     else:

--- a/custom_components/localtuya/manifest.json
+++ b/custom_components/localtuya/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/rospogrigio/localtuya/issues",
   "requirements": [],
-  "version": "5.2.3"
+  "version": "5.2.6"
 }

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -163,6 +163,9 @@ NO_PROTOCOL_HEADER_CMDS = [
 
 HEARTBEAT_INTERVAL = 10
 
+# Default ports to try when connection fails (aligned with tinytuya)
+DEFAULT_PORTS = [6668, 6669, 8681]
+
 # DPS that are known to be safe to use with update_dps (0x12) command
 UPDATE_DPS_WHITELIST = [18, 19, 20]  # Socket (Wi-Fi)
 
@@ -974,7 +977,6 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             MessagePayload(SESS_KEY_NEG_START, self.local_nonce), 2
         )
         if not rkey or not isinstance(rkey, TuyaMessage) or len(rkey.payload) < 48:
-            # error
             self.debug("session key negotiation failed on step 1")
             return False
 
@@ -1174,23 +1176,53 @@ async def connect(
     enable_debug,
     listener=None,
     port=6668,
+    ports=None,
     timeout=5,
 ):
-    """Connect to a device."""
-    loop = asyncio.get_running_loop()
-    on_connected = loop.create_future()
-    _, protocol = await loop.create_connection(
-        lambda: TuyaProtocol(
-            device_id,
-            local_key,
-            protocol_version,
-            enable_debug,
-            on_connected,
-            listener or EmptyListener(),
-        ),
-        address,
-        port,
-    )
+    """Connect to a device.
 
-    await asyncio.wait_for(on_connected, timeout=timeout)
-    return protocol
+    Args:
+        address: Device IP address.
+        device_id: Tuya device ID.
+        local_key: Tuya local key.
+        protocol_version: Protocol version (3.1, 3.2, 3.3, 3.4).
+        enable_debug: Enable debug logging.
+        listener: Optional TuyaListener for status updates.
+        port: Single port to try (used when ports is None).
+        ports: List of ports to try in order. If provided, overrides port.
+        timeout: Connection timeout per port.
+
+    Returns:
+        TuyaProtocol instance on success.
+    """
+    loop = asyncio.get_running_loop()
+    ports_to_try = ports if ports is not None else [port]
+    last_error = None
+
+    for p in ports_to_try:
+        on_connected = loop.create_future()
+        try:
+            _, protocol = await loop.create_connection(
+                lambda oc=on_connected: TuyaProtocol(
+                    device_id,
+                    local_key,
+                    protocol_version,
+                    enable_debug,
+                    oc,
+                    listener or EmptyListener(),
+                ),
+                address,
+                p,
+            )
+            await asyncio.wait_for(on_connected, timeout=timeout)
+            return protocol
+        except (ConnectionRefusedError, ConnectionResetError, OSError) as ex:
+            last_error = ex
+            continue
+        except asyncio.TimeoutError as ex:
+            last_error = ex
+            continue
+
+    if last_error is not None:
+        raise last_error
+    raise ConnectionError("Failed to connect to device")


### PR DESCRIPTION
Fixes issue https://github.com/rospogrigio/localtuya/issues/2189 - LocalTuya 5.2.5 is broken on HA 2026.x

DC Inverter Heat Pumps and similar devices stopped working after firmware update (~2026-03): entities unavailable, 'Connection reset by peer' on 6668.

- Defer add_dps_to_request until after first successful status()
- 1.5s delay after TCP connect before first Tuya packet
- InitialConnectListener: suppress status_updated during handshake
- Port fallback: 6668, 6669, 8681
- Bump version to 5.2.6

Made-with: Cursor