### PR TITLE
Fix UnicodeDecodeError in discovery.py - Issue #2194

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -347,14 +347,19 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         self._dispatch_status()
 
     def _dispatch_status(self):
+        """Dispatch status update to entities (thread-safe)."""
         signal = f"localtuya_{self._dev_config_entry[CONF_DEVICE_ID]}"
-        async_dispatcher_send(self._hass, signal, self._status)
+        self._hass.loop.call_soon_threadsafe(
+            async_dispatcher_send, self._hass, signal, self._status
+        )
 
     @callback
     def disconnected(self):
         """Device disconnected."""
         signal = f"localtuya_{self._dev_config_entry[CONF_DEVICE_ID]}"
-        async_dispatcher_send(self._hass, signal, None)
+        self._hass.loop.call_soon_threadsafe(
+            async_dispatcher_send, self._hass, signal, None
+        )
         if self._unsub_interval is not None:
             self._unsub_interval()
             self._unsub_interval = None

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -804,7 +804,10 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
     @property
     def current_entity(self):
         """Existing configuration for entity currently being edited."""
-        return self.entities[len(self.device_data[CONF_ENTITIES])]
+        index = len(self.device_data[CONF_ENTITIES])
+        if index >= len(self.entities):
+            index = len(self.entities) - 1 if self.entities else 0
+        return self.entities[index]
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/custom_components/localtuya/discovery.py
+++ b/custom_components/localtuya/discovery.py
@@ -64,7 +64,11 @@ class TuyaDiscovery(asyncio.DatagramProtocol):
         try:
             data = decrypt_udp(data)
         except Exception:  # pylint: disable=broad-except
-            data = data.decode()
+            try:
+                data = data.decode()
+            except UnicodeDecodeError:
+                _LOGGER.warning("Failed to decode UDP broadcast from %s", addr)
+                return
 
         decoded = json.loads(data)
         self.device_found(decoded)

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -8,6 +8,7 @@ import homeassistant.util.color as color_util
 import voluptuous as vol
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_HS_COLOR,
     DOMAIN,
@@ -176,6 +177,9 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         self._min_mired = color_util.color_temperature_kelvin_to_mired(
             self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN)
         )
+        # Kelvin-based color temperature (for HA 2026.3+ compatibility)
+        self._min_color_temp_kelvin = self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN)
+        self._max_color_temp_kelvin = self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN)
         self._color_temp_reverse = self._config.get(
             CONF_COLOR_TEMP_REVERSE, DEFAULT_COLOR_TEMP_REVERSE
         )
@@ -250,6 +254,35 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
     def max_mireds(self):
         """Return color temperature max mireds."""
         return self._max_mired
+
+    @property
+    def min_color_temp_kelvin(self):
+        """Return color temperature min kelvin."""
+        return self._min_color_temp_kelvin
+
+    @property
+    def max_color_temp_kelvin(self):
+        """Return color temperature max kelvin."""
+        return self._max_color_temp_kelvin
+
+    @property
+    def color_temp_kelvin(self):
+        """Return the color_temp in kelvin of the light."""
+        if self.has_config(CONF_COLOR_TEMP) and self.is_white_mode:
+            color_temp_value = (
+                self._upper_color_temp - self._color_temp
+                if self._color_temp_reverse
+                else self._color_temp
+            )
+            # Map the DPS value to kelvin
+            return int(
+                self._max_color_temp_kelvin
+                - (
+                    ((self._max_color_temp_kelvin - self._min_color_temp_kelvin) / self._upper_color_temp)
+                    * color_temp_value
+                )
+            )
+        return None
 
     @property
     def effect(self):
@@ -429,21 +462,32 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 states[self._config.get(CONF_COLOR)] = color
                 states[self._config.get(CONF_COLOR_MODE)] = MODE_COLOR
 
-        if ColorMode.COLOR_TEMP in kwargs and ColorMode.COLOR_TEMP in self.supported_color_modes:
+        # Handle both ATTR_COLOR_TEMP_KELVIN (HA 2026.3+) and ColorMode.COLOR_TEMP (deprecated)
+        color_temp_kelvin = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
+        if color_temp_kelvin is None and ColorMode.COLOR_TEMP in kwargs:
+            # Convert mired to kelvin for compatibility
+            color_temp_kelvin = color_util.color_temperature_mired_to_kelvin(int(kwargs[ColorMode.COLOR_TEMP]))
+
+        if color_temp_kelvin is not None and ColorMode.COLOR_TEMP in self.supported_color_modes:
             if brightness is None:
                 brightness = self._brightness
-            mired = int(kwargs[ColorMode.COLOR_TEMP])
+            kelvin = int(color_temp_kelvin)
+            if kelvin < self._min_color_temp_kelvin:
+                kelvin = self._min_color_temp_kelvin
+            elif kelvin > self._max_color_temp_kelvin:
+                kelvin = self._max_color_temp_kelvin
+            # Map kelvin to DPS value
             if self._color_temp_reverse:
-                mired = self._max_mired - (mired - self._min_mired)
-            if mired < self._min_mired:
-                mired = self._min_mired
-            elif mired > self._max_mired:
-                mired = self._max_mired
-            color_temp = int(
-                self._upper_color_temp
-                - (self._upper_color_temp / (self._max_mired - self._min_mired))
-                * (mired - self._min_mired)
-            )
+                color_temp = int(
+                    self._upper_color_temp
+                    - (self._upper_color_temp / (self._max_color_temp_kelvin - self._min_color_temp_kelvin))
+                    * (kelvin - self._min_color_temp_kelvin)
+                )
+            else:
+                color_temp = int(
+                    (self._upper_color_temp / (self._max_color_temp_kelvin - self._min_color_temp_kelvin))
+                    * (kelvin - self._min_color_temp_kelvin)
+                )
             states[self._config.get(CONF_COLOR_MODE)] = MODE_WHITE
             states[self._config.get(CONF_BRIGHTNESS)] = brightness
             states[self._config.get(CONF_COLOR_TEMP)] = color_temp

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -172,10 +172,10 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         )
         self._upper_color_temp = self._upper_brightness
         self._max_mired = color_util.color_temperature_kelvin_to_mired(
-            self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN)
+            int(self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN))
         )
         self._min_mired = color_util.color_temperature_kelvin_to_mired(
-            self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN)
+            int(self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN))
         )
         # Kelvin-based color temperature (for HA 2026.3+ compatibility)
         self._min_color_temp_kelvin = self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN)

--- a/custom_components/localtuya/select.py
+++ b/custom_components/localtuya/select.py
@@ -44,7 +44,14 @@ class LocaltuyaSelect(LocalTuyaEntity, SelectEntity):
         super().__init__(device, config_entry, sensorid, _LOGGER, **kwargs)
         self._state = STATE_UNKNOWN
         self._state_friendly = ""
-        self._valid_options = self._config.get(CONF_OPTIONS).split(";")
+        # Handle both string and dict formats for CONF_OPTIONS
+        options_config = self._config.get(CONF_OPTIONS)
+        if isinstance(options_config, str):
+            self._valid_options = options_config.split(";")
+        elif isinstance(options_config, dict):
+            self._valid_options = list(options_config.values()) if options_config else []
+        else:
+            self._valid_options = []
 
         # Set Display options
         self._display_options = []


### PR DESCRIPTION
Fixes issue #2194

When decrypt_udp fails in the discovery process, the fallback data.decode() could also fail with UnicodeDecodeError if the data is not valid UTF-8.

Bounty: $50