### PR TITLE
Fix type errors in light.py and select.py (#2176)

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -171,10 +171,10 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         )
         self._upper_color_temp = self._upper_brightness
         self._max_mired = color_util.color_temperature_kelvin_to_mired(
-            self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN)
+            int(self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN))
         )
         self._min_mired = color_util.color_temperature_kelvin_to_mired(
-            self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN)
+            int(self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN))
         )
         self._color_temp_reverse = self._config.get(
             CONF_COLOR_TEMP_REVERSE, DEFAULT_COLOR_TEMP_REVERSE

--- a/custom_components/localtuya/select.py
+++ b/custom_components/localtuya/select.py
@@ -44,7 +44,13 @@ class LocaltuyaSelect(LocalTuyaEntity, SelectEntity):
         super().__init__(device, config_entry, sensorid, _LOGGER, **kwargs)
         self._state = STATE_UNKNOWN
         self._state_friendly = ""
-        self._valid_options = self._config.get(CONF_OPTIONS).split(";")
+        options = self._config.get(CONF_OPTIONS)
+        if isinstance(options, str):
+            self._valid_options = options.split(";")
+        elif isinstance(options, dict):
+            self._valid_options = list(options.values())
+        else:
+            self._valid_options = []
 
         # Set Display options
         self._display_options = []


### PR DESCRIPTION
Fixes #2176

- light.py: Convert kelvin config values to int before calculation to fix TypeError
- select.py: Handle both string and dict types for CONF_OPTIONS to fix AttributeError

Error before fix:
```
TypeError: unsupported operand type(s) for /: 'int' and 'str'
AttributeError: 'dict' object has no attribute 'split'
```